### PR TITLE
Include eml_figshare.R in Collate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,3 +27,4 @@ Collate:
     'eml_read.R'
     'eml_import_settings.R'
     'eml_publish.R'
+    'eml_figshare.R'


### PR DESCRIPTION
Include eml_figshare.R in the DESCRIPTION to allow the package to build.
