### PR TITLE
Fix two incorrect URLs in links to md vignettes

### DIFF
--- a/vignettes/README.Rmd
+++ b/vignettes/README.Rmd
@@ -265,7 +265,7 @@ Advanced writing of EML
 **IN PROGRESS**
 
 Our minimal EML file barely scratches the surface of what is possible
-to do with EML.  In [Advanced writing of EML](https://github.com/ropensci/EML/blob/master/inst/doc/vignettes/Advanced_writing_of_EML.md), we construct a much
+to do with EML.  In [Advanced writing of EML](https://github.com/ropensci/EML/blob/master/vignettes/Advanced_writing_of_EML.md), we construct a much
 richer EML file, including:
 
 - Constructing more complete lists of authors, publishers and contact.
@@ -287,7 +287,7 @@ Advanced parsing and manipulation of EML
 
 **IN PROGRESS**
 
-In [Advanced parsing and manipulation of EML](https://github.com/ropensci/EML/blob/master/inst/doc/vignettes/Advanced_parsing_of_EML.md), we
+In [Advanced parsing and manipulation of EML](https://github.com/ropensci/EML/blob/master/vignettes/Advanced_parsing_of_EML.md), we
 
 - Introduce how to access any EML element in R using the S4 subsetting mechanism
 - Demonstrate how to extract and manipulate semantic RDF triples from EML


### PR DESCRIPTION
Looks like the package structure was reorganised to house vignettes in `PKG_HOME/vignettes/` but the URLs in `README.Rmd` were not updated. This commit fixes two of them.
