### PR TITLE
Prettier validation

### DIFF
--- a/R/eml_validate.R
+++ b/R/eml_validate.R
@@ -5,6 +5,8 @@
 #' @param eml an eml class object, file, or xml document
 #' @param ... additional arguments to eml_write, such as namespaces
 #' 
+#' @return Whether the document is valid (logical)
+#' 
 #' @examples \donttest{
 #'  
 #'  f <- system.file("xsd/test", "eml.xml", package = "EML")
@@ -18,10 +20,7 @@
 #'  
 #' ## Can validate fragments as well, though may need the relevant namespace
 #' dataset <- new("dataset", title = "incomplete, invalid EML")
-#' v <- eml_validate(dataset, namespaces = c(ds = "eml://ecoinformatics.org/dataset-2.1.1"), ns = "ds")
-#' 
-#' 
-#' v$errors[[1]]$msg 
+#' eml_validate(dataset, namespaces = c(ds = "eml://ecoinformatics.org/dataset-2.1.1"), ns = "ds")
 #' 
 #' }
 #' 
@@ -33,5 +32,25 @@ eml_validate <- function(eml, ...){
   if(isS4(eml))
     eml <- write_eml(eml, ...)
 
-  xmlSchemaValidate(schema, eml)
+  result <- xmlSchemaValidate(schema, eml)
+  
+  if (result$status != 0) {
+    lapply(result$errors, message_validation_error)
+    
+    return(FALSE)
+  } else {
+    return(TRUE)
+  }
+}
+
+
+#' message_validation_error
+#' 
+#' Create a useful message() for an XML validation error.
+#'
+#' @param error The validation error (XML::XMLError)
+#'
+#' @return Nothing.
+message_validation_error <- function(error) {
+  message(paste0(error$line, ".", error$col, ": ", error$msg))
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -50,8 +50,14 @@ eml
 
 Validate EML against the official schema
 
-```{r}
+```{r, message=TRUE}
+# An EML document with no validation errors
 eml_validate(eml)
+
+# An EML document with validation errors
+invalid_eml <- system.file("tests/testthat/", "example-eml-invalid.xml", package = "EML")
+
+eml_validate(invalid_eml)
 ```
 
 

--- a/inst/examples/example-eml-invalid.xml
+++ b/inst/examples/example-eml-invalid.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<eml:eml
+    packageId="eml.1.1" system="knb"
+    xmlns:eml="eml://ecoinformatics.org/eml-2.1.1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:stmml="http://www.xml-cml.org/schema/stmml-1.1"
+    xsi:schemaLocation="eml://ecoinformatics.org/eml-2.1.1 eml.xsd">
+
+<dataset>
+  <creator id="clarence.lehman">
+    <individualName>
+      <salutation>Mr.</salutation>
+      <givenName>Clarence</givenName>
+      <surName>Lehman</surName>
+    </individualName>
+  </creator>
+  <contact>
+    <references>clarence.lehman</references>
+  </contact>
+</dataset>
+</eml:eml>

--- a/inst/examples/example-eml-valid.xml
+++ b/inst/examples/example-eml-valid.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<eml:eml
+    packageId="eml.1.1" system="knb"
+    xmlns:eml="eml://ecoinformatics.org/eml-2.1.1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:stmml="http://www.xml-cml.org/schema/stmml-1.1"
+    xsi:schemaLocation="eml://ecoinformatics.org/eml-2.1.1 eml.xsd">
+
+<dataset>
+  <title>Data from Cedar Creek LTER on productivity and species richness
+  for use in a workshop titled "An Analysis of the Relationship between
+  Productivity and Diversity using Experimental Results from the Long-Term
+  Ecological Research Network" held at NCEAS in September 1996.</title>
+  <creator id="clarence.lehman">
+    <individualName>
+      <salutation>Mr.</salutation>
+      <givenName>Clarence</givenName>
+      <surName>Lehman</surName>
+    </individualName>
+  </creator>
+  <contact>
+    <references>clarence.lehman</references>
+  </contact>
+</dataset>
+</eml:eml>

--- a/tests/testthat/example-eml-invalid.xml
+++ b/tests/testthat/example-eml-invalid.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<eml:eml
+    packageId="eml.1.1" system="knb"
+    xmlns:eml="eml://ecoinformatics.org/eml-2.1.1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:stmml="http://www.xml-cml.org/schema/stmml-1.1"
+    xsi:schemaLocation="eml://ecoinformatics.org/eml-2.1.1 eml.xsd">
+
+<dataset>
+  <creator id="clarence.lehman">
+    <individualName>
+      <salutation>Mr.</salutation>
+      <givenName>Clarence</givenName>
+      <surName>Lehman</surName>
+    </individualName>
+  </creator>
+  <contact>
+    <references>clarence.lehman</references>
+  </contact>
+</dataset>
+</eml:eml>

--- a/tests/testthat/example-eml-valid.xml
+++ b/tests/testthat/example-eml-valid.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<eml:eml
+    packageId="eml.1.1" system="knb"
+    xmlns:eml="eml://ecoinformatics.org/eml-2.1.1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:stmml="http://www.xml-cml.org/schema/stmml-1.1"
+    xsi:schemaLocation="eml://ecoinformatics.org/eml-2.1.1 eml.xsd">
+
+<dataset>
+  <title>Data from Cedar Creek LTER on productivity and species richness
+  for use in a workshop titled "An Analysis of the Relationship between
+  Productivity and Diversity using Experimental Results from the Long-Term
+  Ecological Research Network" held at NCEAS in September 1996.</title>
+  <creator id="clarence.lehman">
+    <individualName>
+      <salutation>Mr.</salutation>
+      <givenName>Clarence</givenName>
+      <surName>Lehman</surName>
+    </individualName>
+  </creator>
+  <contact>
+    <references>clarence.lehman</references>
+  </contact>
+</dataset>
+</eml:eml>

--- a/tests/testthat/test-eml.R
+++ b/tests/testthat/test-eml.R
@@ -8,11 +8,11 @@ testthat::test_that("We can parse the sample EML file correctly", {
 
   ## FIXME: even basic schema validation needs network connection for w3.org schema checks
   check <- eml_validate(eml)
-  testthat::expect_equal(check$status, 0)
+  testthat::expect_true(check)
 
   write_eml(eml, "test.xml")
   check2 <- eml_validate("test.xml")
-  testthat::expect_equal(check2$status, 0)
+  testthat::expect_true(check2)
 
   unlink("test.xml")
 

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -1,0 +1,19 @@
+testthat::context("Validating EML documents")
+
+testthat::test_that("We return TRUE when validating valid documents", {
+  library("XML")
+  
+  f <- system.file("tests/testthat/", "example-eml-valid.xml", package = "EML")
+
+  testthat::expect_true(eml_validate(f))
+  testthat::expect_message(eml_validate(f), NA)
+})
+
+testthat::test_that("We return FALSE and messages when validating invalid documents", {
+  library("XML")
+  
+  f <- system.file("tests/testthat/", "example-eml-invalid.xml", package = "EML")
+
+  testthat::expect_false(eml_validate(f))
+  testthat::expect_message(eml_validate(f))
+})

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -3,7 +3,7 @@ testthat::context("Validating EML documents")
 testthat::test_that("We return TRUE when validating valid documents", {
   library("XML")
   
-  f <- system.file("tests/testthat/", "example-eml-valid.xml", package = "EML")
+  f <- system.file("examples", "example-eml-valid.xml", package = "EML")
 
   testthat::expect_true(eml_validate(f))
   testthat::expect_message(eml_validate(f), NA)
@@ -12,7 +12,7 @@ testthat::test_that("We return TRUE when validating valid documents", {
 testthat::test_that("We return FALSE and messages when validating invalid documents", {
   library("XML")
   
-  f <- system.file("tests/testthat/", "example-eml-invalid.xml", package = "EML")
+  f <- system.file("examples", "example-eml-invalid.xml", package = "EML")
 
   testthat::expect_false(eml_validate(f))
   testthat::expect_message(eml_validate(f))


### PR DESCRIPTION
Addresses #148 

PR contains:

- A pair of (simple) tests
- Updated roxygen block for eml_validate
- Two sample EML files in tests/testthat (valid and invalid)
- Updated readme Rmd for new validate behavior

eml_validate now produces output like:

```
> eml_validate(invalid_eml)
3.0: Element 'creator': This element is not expected. Expected is one of ( references, alternateIdentifier, shortName, title ).

[1] FALSE
```