### PR TITLE
Encoding in eml_validate

### DIFF
--- a/R/eml_validate.R
+++ b/R/eml_validate.R
@@ -4,7 +4,7 @@
 #' validate_eml
 #' @param eml an eml class object, file, or xml document
 #' @param encoding optional, if eml is a file path / an eml and has special characters, one can 
-#' give the encoding used by xmlParse.
+#' gives the encoding used by xmlParse.
 #' @param ... additional arguments to eml_write, such as namespaces
 #' 
 #' @return Whether the document is valid (logical)

--- a/R/eml_validate.R
+++ b/R/eml_validate.R
@@ -3,6 +3,8 @@
 #'
 #' validate_eml
 #' @param eml an eml class object, file, or xml document
+#' @param encoding optional, if eml is a file path / an eml and has special characters, one can 
+#' give the encoding used by xmlParse.
 #' @param ... additional arguments to eml_write, such as namespaces
 #' 
 #' @return Whether the document is valid (logical)
@@ -25,13 +27,16 @@
 #' }
 #' 
 #' @export
-eml_validate <- function(eml, ...){
-
+eml_validate <- function(eml, encoding = NULL, ...){
+  
   schema <- system.file("xsd/eml.xsd", package = "EML") #"http://ropensci.github.io/EML/eml.xsd"
-
+  
   if(isS4(eml))
     eml <- write_eml(eml, ...)
-
+  
+  
+  eml <- xmlParse(eml, encoding = encoding)
+  
   result <- xmlSchemaValidate(schema, eml)
   
   if (result$status != 0) {

--- a/inst/examples/example-eml-valid-special-characters.xml
+++ b/inst/examples/example-eml-valid-special-characters.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<eml:eml
+    packageId="eml.1.1" system="knb"
+    xmlns:eml="eml://ecoinformatics.org/eml-2.1.1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:stmml="http://www.xml-cml.org/schema/stmml-1.1"
+    xsi:schemaLocation="eml://ecoinformatics.org/eml-2.1.1 eml.xsd">
+
+<dataset>
+  <title>Data from Cedar Creek LTER on productivity and species richness
+  for use in a workshop titled "An Analysis of the Relationship between
+  Productivity and Diversity using Experimental Results from the Long-Term
+  Ecological Research Network" held at NCEAS in September 1996.</title>
+  <creator id="clarence.lehman">
+    <individualName>
+      <salutation>Mr.</salutation>
+      <givenName>Maël</givenName>
+      <surName>Lehman</surName>
+    </individualName>
+  </creator>
+  <contact>
+    <references>clarence.lehman</references>
+  </contact>
+</dataset>
+</eml:eml>

--- a/man/eml_validate.Rd
+++ b/man/eml_validate.Rd
@@ -4,10 +4,13 @@
 \alias{eml_validate}
 \title{validate_eml}
 \usage{
-eml_validate(eml, ...)
+eml_validate(eml, encoding = NULL, ...)
 }
 \arguments{
 \item{eml}{an eml class object, file, or xml document}
+
+\item{encoding}{optional, if eml is a file path / an eml and has special characters, one can 
+gives the encoding used by xmlParse.}
 
 \item{...}{additional arguments to eml_write, such as namespaces}
 }

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -7,6 +7,12 @@ testthat::test_that("We return TRUE when validating valid documents", {
 
   testthat::expect_true(eml_validate(f))
   testthat::expect_message(eml_validate(f), NA)
+  
+  
+  f2 <- system.file("examples", "example-eml-valid-special-characters.xml", package = "EML")
+  
+  testthat::expect_true(eml_validate(f2, encoding = "latin1"))
+  testthat::expect_message(eml_validate(f2, encoding = "latin1"), NA)
 })
 
 testthat::test_that("We return FALSE and messages when validating invalid documents", {


### PR DESCRIPTION
Reference issue: https://github.com/ropensci/EML/issues/159

It seems that xmlSchemaValidate does not accept any argument for xmlParse, so the encoding argument has to be passed to xmlParse, therefore I externalized the xmlParse call that in the current version of EML is made in xmlSchemaValidate.

I have added a test with a eml with a special character.