### PR TITLE
Mostly set_attributes work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 # Sample .travis.yml for R projects
 
 language: r
+r:
+  - oldrel
+  - release
+  - devel
 warnings_are_errors: true
 sudo: required

--- a/R/coercions.R
+++ b/R/coercions.R
@@ -18,10 +18,16 @@ c_as <- function(x, cls){
 setOldClass("person")
 
 from_a_person <- function(to){
+
   
   if(to %in% c("associatedParty", "personnel"))
   
+    
   function(from){
+    if(is.null(from$role)){
+      warning(paste0("Person ", as.character(from), " was not given any role."),
+              call. = FALSE)
+    }  
   new(to,
       individualName = new("individualName",
                            "givenName" = as.character(from$given),
@@ -33,7 +39,11 @@ from_a_person <- function(to){
   else
     
     function(from){
-      new(to,
+      if(is.null(from$role)){
+        warning(paste0("Person ", as.character(from), " was not given any role."),
+                call. = FALSE)
+      }  
+     new(to,
           individualName = new("individualName",
                                "givenName" = as.character(from$given),
                                "surName" = as(as.character(from$family), "surName")),

--- a/R/eml_validate.R
+++ b/R/eml_validate.R
@@ -31,17 +31,18 @@ eml_validate <- function(eml, encoding = NULL, ...){
   
   schema <- system.file("xsd/eml.xsd", package = "EML") #"http://ropensci.github.io/EML/eml.xsd"
   
-  if(isS4(eml))
+  # validation is based on the xml format not the S4 object
+  if(isS4(eml)){
     eml <- write_eml(eml, ...)
-  
-  
+  }
+
+  # the encoding argument can only be passed to xmlParse directly
   eml <- xmlParse(eml, encoding = encoding)
   
   result <- xmlSchemaValidate(schema, eml)
   
   if (result$status != 0) {
     lapply(result$errors, message_validation_error)
-    
     return(FALSE)
   } else {
     return(TRUE)

--- a/R/eml_validate.R
+++ b/R/eml_validate.R
@@ -33,7 +33,7 @@ eml_validate <- function(eml, encoding = NULL, ...){
   
   # validation is based on the xml format not the S4 object
   if(isS4(eml)){
-    eml <- write_eml(eml, ...)
+    eml <- write_eml(eml, encoding = encoding, ...)
   }
 
   # the encoding argument can only be passed to xmlParse directly

--- a/R/set_attributes.R
+++ b/R/set_attributes.R
@@ -40,13 +40,10 @@ set_attributes <- function(attributes, factors = NULL, col_classes = NULL){
   if(! "attributeName" %in% names(attributes))
     stop("attributes table must include an 'attributeName' column")
 
-  ## Factors table must be all of type character!  
-  if(!is.null(factors))
-    factors <- data.frame(lapply(factors, as.character), stringsAsFactors = FALSE)
-  
   ## infer "domain" & "measurementScale" given optional column classes
   if(!is.null(col_classes))
-    attributes <- merge(attributes, infer_domain_scale(col_classes, attributes$attributeName), all = TRUE)
+    attributes <- merge(attributes, infer_domain_scale(col_classes, attributes$attributeName), all = TRUE, sort = FALSE)
+  
   ## Add NA columns if necessary FIXME some of these can be missing if their class isn't represented, but otherwise must be present
   for(x in c("precision", "minimum", "maximum", "unit", "numberType", "formatString", "definition",
                          "pattern", "source", "attributeLabel", "storageType", "missingValueCode",

--- a/R/set_coverage.R
+++ b/R/set_coverage.R
@@ -22,7 +22,23 @@
 #' @export
 #'
 #' @examples
-#' 
+#' coverage <- 
+#' set_coverage(begin = '2012-06-01', end = '2013-12-31',
+#'              sci_names = "Sarracenia purpurea",
+#'              geographicDescription = geographicDescription,
+#'              west = -122.44, east = -117.15, 
+#'              north = 37.38, south = 30.00,
+#'              altitudeMin = 160, altitudeMaximum = 330,
+#'             altitudeUnits = "meter")
+#' geographicDescription <- "The Geographic region of the kelp bed data
+#'  extends along the California coast, down through 
+#'  the coast of Baja, Mexico: Central California
+#'   (Halfmoon Bay to Purisima Point), 
+#'   Southern California (Point Arguello to 
+#'   the United States/Mexico border including the 
+#'   Channel Islands) and Baja California (points south
+#'    of the United States/Mexico border including several 
+#'    offshore islands)"
 #'coverage <- 
 #'  set_coverage(begin = '2012-06-01', end = '2013-12-31',
 #'               sci_names = "Sarracenia purpurea",

--- a/R/set_coverage.R
+++ b/R/set_coverage.R
@@ -22,23 +22,6 @@
 #' @export
 #'
 #' @examples
-#' coverage <- 
-#' set_coverage(begin = '2012-06-01', end = '2013-12-31',
-#'              sci_names = "Sarracenia purpurea",
-#'              geographicDescription = geographicDescription,
-#'              west = -122.44, east = -117.15, 
-#'              north = 37.38, south = 30.00,
-#'              altitudeMin = 160, altitudeMaximum = 330,
-#'             altitudeUnits = "meter")
-#' geographicDescription <- "The Geographic region of the kelp bed data
-#'  extends along the California coast, down through 
-#'  the coast of Baja, Mexico: Central California
-#'   (Halfmoon Bay to Purisima Point), 
-#'   Southern California (Point Arguello to 
-#'   the United States/Mexico border including the 
-#'   Channel Islands) and Baja California (points south
-#'    of the United States/Mexico border including several 
-#'    offshore islands)"
 #'coverage <- 
 #'  set_coverage(begin = '2012-06-01', end = '2013-12-31',
 #'               sci_names = "Sarracenia purpurea",

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -3,4 +3,3 @@
 ## FIXME consider sysdata for this?
 standardUnits <- get_unitList()
 
-

--- a/README.Rmd
+++ b/README.Rmd
@@ -65,7 +65,7 @@ Validate EML against the official schema
 eml_validate(eml)
 
 # An EML document with validation errors
-invalid_eml <- system.file("tests/testthat/", "example-eml-invalid.xml", package = "EML")
+invalid_eml <- system.file("xsd/test/example-eml-invalid.xml", package = "EML")
 
 eml_validate(invalid_eml)
 ```
@@ -74,7 +74,7 @@ eml_validate(invalid_eml)
 Write out as EML:
 
 
-```{r}
+```{r, eval=FALSE}
 write_eml(eml, "example.xml")
 ```
 
@@ -105,3 +105,6 @@ One of the chief advantages of using EML to manage your own data is the improved
 ### Creating EML class definitions 
 
 Class definitions (`classes.R`) and methods (`methods.R`) are created programmatically.  From the root of the package, run: `source("inst/create-package/create_package.R")`.  
+
+### Meta
+Please note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ eml_validate(eml)
 #> [1] TRUE
 
 # An EML document with validation errors
-invalid_eml <- system.file("tests/testthat/", "example-eml-invalid.xml", package = "EML")
+invalid_eml <- system.file("xsd/test/example-eml-invalid.xml", package = "EML")
 
 eml_validate(invalid_eml)
 #> 10.0: Element 'creator': This element is not expected. Expected is one of ( references, alternateIdentifier, shortName, title ).
@@ -117,7 +117,6 @@ Write out as EML:
 
 ``` r
 write_eml(eml, "example.xml")
-#> [1] "example.xml"
 ```
 
 Reading EML files
@@ -146,3 +145,7 @@ Developer notes
 ### Creating EML class definitions
 
 Class definitions (`classes.R`) and methods (`methods.R`) are created programmatically. From the root of the package, run: `source("inst/create-package/create_package.R")`.
+
+### Meta
+
+Please note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.

--- a/inst/xsd/test/example-eml-invalid.xml
+++ b/inst/xsd/test/example-eml-invalid.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<eml:eml
+    packageId="eml.1.1" system="knb"
+    xmlns:eml="eml://ecoinformatics.org/eml-2.1.1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:stmml="http://www.xml-cml.org/schema/stmml-1.1"
+    xsi:schemaLocation="eml://ecoinformatics.org/eml-2.1.1 eml.xsd">
+
+<dataset>
+  <creator id="clarence.lehman">
+    <individualName>
+      <salutation>Mr.</salutation>
+      <givenName>Clarence</givenName>
+      <surName>Lehman</surName>
+    </individualName>
+  </creator>
+  <contact>
+    <references>clarence.lehman</references>
+  </contact>
+</dataset>
+</eml:eml>

--- a/man/set_attributes.Rd
+++ b/man/set_attributes.Rd
@@ -28,10 +28,12 @@ headers shown here.  The attributes data frame must contain columns for required
 These are:
 
 For all data:
-- attributeName (required)
-- attributeDefinition (required)
-- measurementScale (required)
-- domain (required)
+- attributeName (required, free text field)
+- attributeDefinition (required, free text field)
+- measurementScale (required, "nominal", "ordinal", "ratio", "interval", or "dateTime",
+ case sensitive) but it can be inferred from col_classes.
+- domain (required, "numericDomain", "textDomain", "enumeratedDomain", or "dateTimeDomain",
+ case sensitive) but it can be inferred from col_classes.
 
 For numeric (ratio or interval) data:
 - unit (required)

--- a/man/set_coverage.Rd
+++ b/man/set_coverage.Rd
@@ -50,7 +50,6 @@ well suited, and users will need the more flexible but more verbose construction
 of calendar dates, or to specify taxonomic coverage in terms of other ranks or identifiers.
 }
 \examples{
-
 coverage <- 
  set_coverage(begin = '2012-06-01', end = '2013-12-31',
               sci_names = "Sarracenia purpurea",

--- a/tests/testthat/test-attributes.R
+++ b/tests/testthat/test-attributes.R
@@ -34,3 +34,202 @@ testthat::test_that("we can have numeric data with bounds where some bounds are 
 
 
 })
+
+testthat::test_that("The set_attributes function works for the vignette example",{
+  attributes <-
+    data.frame(
+      attributeName = c(
+        "run.num",
+        "year",
+        "day",
+        "hour.min",
+        "i.flag",
+        "variable",
+        "value.i",
+        "length"), 
+      formatString = c(
+        NA,        
+        "YYYY",     
+        "DDD",      
+        "hhmm",     
+        NA,         
+        NA,         
+        NA,
+        NA),
+      definition = c(        
+        "which run number",
+        NA,
+        NA,
+        NA,
+        NA,
+        NA, 
+        NA,
+        NA),
+      unit = c(
+        NA,
+        NA,
+        NA,
+        NA,
+        NA,
+        NA,
+        NA,
+        "meter"),
+      attributeDefinition = c(
+        "which run number (=block). Range: 1 - 6. (integer)",
+        "year, 2012",
+        "Julian day. Range: 170 - 209.",
+        "hour and minute of observation. Range 1 - 2400 (integer)",
+        "is variable Real, Interpolated or Bad (character/factor)",
+        "what variable being measured in what treatment (character/factor).",
+        "value of measured variable for run.num on year/day/hour.min.",
+        "length of the species in meters (dummy example of numeric data)"),
+      numberType = c(
+        NA,
+        NA,
+        NA,
+        NA,
+        NA,
+        NA,
+        NA,
+        "real"),
+      stringsAsFactors = FALSE
+    )
+  i.flag <- c(R = "real",
+              I = "interpolated",
+              B = "bad")
+  variable <- c(
+    control  = "no prey added",
+    low      = "0.125 mg prey added ml-1 d-1",
+    med.low  = "0,25 mg prey added ml-1 d-1",
+    med.high = "0.5 mg prey added ml-1 d-1",
+    high     = "1.0 mg prey added ml-1 d-1",
+    air.temp = "air temperature measured just above all plants (1 thermocouple)",
+    water.temp = "water temperature measured within each pitcher",
+    par       = "photosynthetic active radiation (PAR) measured just above all plants (1 sensor)"
+  )
+  
+  value.i <- c(
+    control  = "% dissolved oxygen",
+    low      = "% dissolved oxygen",
+    med.low  = "% dissolved oxygen",
+    med.high = "% dissolved oxygen",
+    high     = "% dissolved oxygen",
+    air.temp = "degrees C",
+    water.temp = "degrees C",
+    par      = "micromoles m-1 s-1"
+  )
+  
+  ## Write these into the data.frame format
+  factors <- rbind(
+    data.frame(
+      attributeName = "i.flag",
+      code = names(i.flag),
+      definition = unname(i.flag)
+    ),
+    data.frame(
+      attributeName = "variable",
+      code = names(variable),
+      definition = unname(variable)
+    ),
+    data.frame(
+      attributeName = "value.i",
+      code = names(value.i),
+      definition = unname(value.i)
+    )
+  )
+  attributeList <- set_attributes(attributes, factors, col_classes = c("character", "Date", "Date", "Date", "factor", "factor", "factor", "numeric"))
+  testthat::expect_is(attributeList, "attributeList")
+})
+
+testthat::test_that("The set_attributes function stops if missing required fields in attributes",{
+  # attributeName
+  attributes <- data.frame(attributeName = NA,
+                           attributeDefinition = "date",
+                           measurementScale = "dateTime",
+                           domain = "dateTimeDomain",
+                           formatString = "YYMMDD")
+  
+  testthat::expect_error(set_attributes(attributes))
+  
+  attributes <- data.frame(attributeDefinition = "date",
+                           measurementScale = "dateTime",
+                           domain = "dateTimeDomain",
+                           formatString = "YYMMDD")
+  
+  testthat::expect_error(set_attributes(attributes))
+  
+  # attributeDefinition
+  attributes <- data.frame(attributeName = "date",
+                           measurementScale = "dateTime",
+                           domain = "dateTimeDomain",
+                           formatString = "YYMMDD")
+  
+  testthat::expect_error(set_attributes(attributes))
+  
+  
+  attributes <- data.frame(attributeName = "date",
+                           attributeDefinition = NA,
+                           measurementScale = "dateTime",
+                           domain = "dateTimeDomain",
+                           formatString = "YYMMDD")
+  
+  testthat::expect_error(set_attributes(attributes))
+  
+  # measurementScale
+  attributes <- data.frame(attributeName = "date",
+                           attributeDefinition = "date",
+                           domain = "dateTimeDomain",
+                           formatString = "YYMMDD")
+  
+  testthat::expect_error(set_attributes(attributes))
+  
+  attributes <- data.frame(attributeName = "date",
+                           attributeDefinition = "date",
+                           measurementScale = NA,
+                           domain = "dateTimeDomain",
+                           formatString = "YYMMDD")
+  
+  testthat::expect_error(set_attributes(attributes))
+  
+  attributes <- data.frame(attributeName = "date",
+                           attributeDefinition = "date",
+                           measurementScale = "datetime",
+                           domain = "dateTimeDomain",
+                           formatString = "YYMMDD")
+  
+  testthat::expect_error(set_attributes(attributes))
+  
+  # domain
+  attributes <- data.frame(attributeName = "date",
+                           attributeDefinition = "date",
+                           measurementScale = "dateTime",
+                           formatString = "YYMMDD")
+  
+  testthat::expect_error(set_attributes(attributes))
+  
+  attributes <- data.frame(attributeName = "date",
+                           attributeDefinition = "date",
+                           measurementScale = "dateTime",
+                           domain = NA,
+                           formatString = "YYMMDD")
+  
+  testthat::expect_error(set_attributes(attributes))
+  
+  attributes <- data.frame(attributeName = "date",
+                           attributeDefinition = "date",
+                           measurementScale = "dateTime",
+                           domain = "numberdomain",
+                           formatString = "YYMMDD")
+  
+  testthat::expect_error(set_attributes(attributes))
+})
+
+testthat::test_that("The set_attributes function returns useful warnings",{
+  attributes <- data.frame(attributeName = "date",
+                           attributeDefinition = "date",
+                           measurementScale = "dateTime",
+                           domain = "dateTimeDomain")
+  
+  testthat::expect_warning(set_attributes(attributes),
+                           "The required formatString")
+})

--- a/tests/testthat/test-coercions.R
+++ b/tests/testthat/test-coercions.R
@@ -10,6 +10,8 @@ to <- as(x, "associatedParty")
 testthat::expect_is(to, "associatedParty")
 
 
+
+
 x = as.person("Carl David Boettiger <cboettig@gmail.com> [ctb]")
 to <- as(x, "associatedParty")
 testthat::expect_is(to, "associatedParty")
@@ -21,3 +23,10 @@ x <- as(citation, "bibentry")
 testthat::expect_is(x, "bibentry")
 y <- as(x, "citation")
 testthat::expect_is(y, "citation")
+
+testthat::test_that("warning when no role given to a person",{
+  x = as.person("Carl Boettiger <cboettig@gmail.com>")
+  testthat::expect_warning(as(x, "associatedParty"))
+  x = as.person("Carl Boettiger <cboettig@gmail.com>")
+  testthat::expect_warning(as(x, "contact"))
+})

--- a/tests/testthat/test-coverage.R
+++ b/tests/testthat/test-coverage.R
@@ -1,0 +1,15 @@
+testthat::context("Creating coverage")
+testthat::test_that("set_coverage creates a coverage object",{
+  geographicDescription <- "The Geographic region of the kelp bed data extends along the California coast, down through the coast of Baja, Mexico: Central California (Halfmoon Bay to Purisima Point), Southern California (Point Arguello to the United States/Mexico border including the Channel Islands) and Baja California (points south of the United States/Mexico border including several offshore islands)"
+  
+  coverage <- 
+    set_coverage(begin = '2012-06-01', end = '2013-12-31',
+                 sci_names = "Sarracenia purpurea",
+                 geographicDescription = geographicDescription,
+                 west = -122.44, east = -117.15, 
+                 north = 37.38, south = 30.00,
+                 altitudeMin = 160, altitudeMaximum = 330,
+                 altitudeUnits = "meter")
+  
+  testthat::expect_is(coverage, "coverage")
+  })

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -15,6 +15,21 @@ testthat::test_that("We return TRUE when validating valid documents", {
   testthat::expect_message(eml_validate(f2, encoding = "latin1"), NA)
 })
 
+testthat::test_that("We return TRUE when validating valid eml objects", {
+  library("XML")
+  
+  f <- system.file("examples", "example-eml-valid.xml", package = "EML")
+  eml <- read_eml(f)
+  testthat::expect_true(eml_validate(eml))
+  testthat::expect_message(eml_validate(eml), NA)
+  
+  
+  f2 <- system.file("examples", "example-eml-valid-special-characters.xml", package = "EML")
+  eml2 <- read_eml(f2)
+  testthat::expect_true(eml_validate(eml2, encoding = "latin1"))
+  testthat::expect_message(eml_validate(eml2, encoding = "latin1"), NA)
+})
+
 testthat::test_that("We return FALSE and messages when validating invalid documents", {
   library("XML")
   

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -25,7 +25,7 @@ testthat::test_that("We return TRUE when validating valid eml objects", {
   
   
   f2 <- system.file("examples", "example-eml-valid-special-characters.xml", package = "EML")
-  eml2 <- read_eml(f2)
+  eml2 <- read_eml(f2, encoding = "latin1")
   testthat::expect_true(eml_validate(eml2, encoding = "latin1"))
   testthat::expect_message(eml_validate(eml2, encoding = "latin1"), NA)
 })


### PR DESCRIPTION
* I added a mention to CONDUCT.md in the footer.

* I have added errors when there are missing or not valid fields in `attributes`: `attributeName`, `attributeDefinition`, `measurementScale` and `domain` (`measurementScale` and `domain` are checked after they've been complemented with `col_classes`). Since the rest of the function uses these fields, I think it's better to have errors than warnings for these fields. For instance, if `measurementScale` is missing or has non permitted values, the line `s <- row[["measurementScale"]]` would provoke an error anyway. But I can transform them into warnings if you don't agree!

* I have added a warning when `formatString` is missing for a `dateTime`. This is the first of many warnings I'd like to add in the future.

* I have added tests. By the way, would you like to measure coverage via covr+codecov.io?