### PR TITLE
Following the previous PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,9 @@ r:
   - devel
 warnings_are_errors: true
 sudo: required
+
+r_github_packages:
+- jimhester/covr
+
+after_success:
+- Rscript -e 'library(covr); codecov()'

--- a/R/set_attributes.R
+++ b/R/set_attributes.R
@@ -214,6 +214,11 @@ na2empty <- function(x){
 }
 
 check_and_complete_attributes <- function(attributes, col_classes){
+  if(length(col_classes) != nrow(attributes)){
+    stop(call. = FALSE,
+         "If col_classes is not NULL, it must have as many elements as there are rows in attributes.")
+  }
+  
   if(! "attributeName" %in% names(attributes)){
     stop(call. = FALSE, "attributes table must include an 'attributeName' column")
   }else{

--- a/R/set_attributes.R
+++ b/R/set_attributes.R
@@ -6,7 +6,8 @@
 #' @param factors a table with factor code-definition pairs; see details
 #' @param col_classes optional, list of R column classes ('ordered', 'numeric', 'factor', 'Date', or 'character', case sensitive)
 #' will let the function infer missing 'domain' and 'measurementScale' values for attributes column.
-#' Should be in same order as attributeNames in the attribute table, or be a named list.
+#' Should be in same order as attributeNames in the attributes table, or be a named list with names corresponding to attributeNames
+#' in the attributes table.
 #' @details The attributes data frame must use only the recognized column
 #' headers shown here.  The attributes data frame must contain columns for required metadata.
 #' These are:

--- a/R/set_attributes.R
+++ b/R/set_attributes.R
@@ -4,7 +4,7 @@
 #' @param attributes a joined table of all attribute metadata
 #' (such as returned by \code{\link{get_attributes}}, see details)
 #' @param factors a table with factor code-definition pairs; see details
-#' @param col_classes optional, list of R column classes (numeric, factor, date, character)
+#' @param col_classes optional, list of R column classes ('numeric', 'factor', 'Date', or 'character', case sensitive)
 #' will let the function infer missing 'domain' and 'measurementScale' values for attributes column.
 #' Should be in same order as attributeNames in the attribute table, or be a named list.
 #' @details The attributes data frame must use only the recognized column
@@ -167,6 +167,9 @@ set_BoundsGroup <- function(row, cls = "BoundsGroup"){
 
 
 infer_domain_scale <- function(col_classes, attributeName = names(col_classes)){
+  if(!(all(col_classes %in% c("numeric", "character", "factor", "Date")))){
+    stop(call. = FALSE, "All col_classes values have to be 'numeric', 'character', 'factor' or 'Date'.")
+  }
   domain <- col_classes
   measurementScale <- col_classes
   storageType <- col_classes
@@ -233,27 +236,27 @@ check_and_complete_attributes <- function(attributes, col_classes){
   
   
   if(! "measurementScale" %in% names(attributes)){
-    stop(call. = FALSE, "attributes table must include an 'measurementScale' column")
+    stop(call. = FALSE, "attributes table must include an 'measurementScale' column, or you need to input 'col_classes'.")
   }else{
     if(any(is.na(attributes$measurementScale))){
       stop(call. = FALSE, "The measurementScale column must be filled for each attribute.")
     }else{
       if(!(all(attributes$measurementScale %in% c("nominal", "ordinal", "ratio",
                                                   "interval", "dateTime")))){
-        stop(call. = FALSE, "measurementScale permitted values are nominal, ordinal, ratio, interval, dateTime.")
+        stop(call. = FALSE, "measurementScale permitted values are 'nominal', 'ordinal', 'ratio', 'interval', 'dateTime'.")
       }
     }
   }
   
   
   if(! "domain" %in% names(attributes)){
-    stop(call. = FALSE, "attributes table must include an 'domain' column")
+    stop(call. = FALSE, "attributes table must include an 'domain' column, or you need to input 'col_classes'.")
   }else{
     if(any(is.na(attributes$domain))){
       stop(call. = FALSE, "The domain column must be filled for each attribute.")
     }else{
       if(!(all(attributes$domain %in% c("numericDomain", "textDomain", "enumeratedDomain", "dateTimeDomain")))){
-        stop(call. = FALSE, "domain permitted values are numericDomain, textDomain, enumeratedDomain, dateTimeDomain.")
+        stop(call. = FALSE, "domain permitted values are 'numericDomain', 'textDomain', 'enumeratedDomain', 'dateTimeDomain'.")
       }
     }
   }

--- a/R/set_attributes.R
+++ b/R/set_attributes.R
@@ -39,6 +39,7 @@ set_attributes <- function(attributes, factors = NULL, col_classes = NULL){
   factors[]  <- lapply(factors, as.character)
   ##  check attributes data.frame.  must declare required columns: attributeName, (attributeDescription, ....)
   ## infer "domain" & "measurementScale" given optional column classes
+  
   attributes <- check_and_complete_attributes(attributes, col_classes)
   
  
@@ -166,7 +167,22 @@ set_BoundsGroup <- function(row, cls = "BoundsGroup"){
 
 
 
-infer_domain_scale <- function(col_classes, attributeName = names(col_classes)){
+infer_domain_scale <- function(col_classes, attributeName = names(col_classes), attributes){
+  
+  if(length(col_classes) != nrow(attributes)){
+    if(is.null(names(col_classes))){
+      stop(call. = FALSE,
+           "If col_classes is not NULL, it must have as many elements as there are rows in attributes unless they are named.")
+      
+    }
+  }
+  if(!is.null(names(col_classes))){
+    if(!(all(names(col_classes) %in% attributeName))){
+      stop(call. = FALSE,
+           "If col_classes is a named list, it should have names corresponding to attributeName.")
+    }
+  }
+  
   if(!(all(col_classes[!is.na(col_classes)] %in% c("numeric", "character", "factor", "Date", "ordered")))){
     stop(call. = FALSE, "All non missing col_classes values have to be 'ordered', 'numeric', 'character', 'factor' or 'Date'.")
   }
@@ -214,10 +230,7 @@ na2empty <- function(x){
 }
 
 check_and_complete_attributes <- function(attributes, col_classes){
-  if(length(col_classes) != nrow(attributes)){
-    stop(call. = FALSE,
-         "If col_classes is not NULL, it must have as many elements as there are rows in attributes.")
-  }
+ 
   
   if(! "attributeName" %in% names(attributes)){
     stop(call. = FALSE, "attributes table must include an 'attributeName' column")
@@ -229,7 +242,8 @@ check_and_complete_attributes <- function(attributes, col_classes){
   
   ## infer "domain" & "measurementScale" given optional column classes
   if(!is.null(col_classes))
-    attributes <- merge(attributes, infer_domain_scale(col_classes, attributes$attributeName), all = TRUE, sort = FALSE)
+    attributes <- merge(attributes, infer_domain_scale(col_classes, attributes$attributeName,
+                                                       attributes), all = TRUE, sort = FALSE)
   
   if(! "attributeDefinition" %in% names(attributes)){
     stop(call. = FALSE, "attributes table must include an 'attributeDefinition' column")

--- a/R/set_attributes.R
+++ b/R/set_attributes.R
@@ -4,7 +4,7 @@
 #' @param attributes a joined table of all attribute metadata
 #' (such as returned by \code{\link{get_attributes}}, see details)
 #' @param factors a table with factor code-definition pairs; see details
-#' @param col_classes optional, list of R column classes ('numeric', 'factor', 'Date', or 'character', case sensitive)
+#' @param col_classes optional, list of R column classes ('ordered', 'numeric', 'factor', 'Date', or 'character', case sensitive)
 #' will let the function infer missing 'domain' and 'measurementScale' values for attributes column.
 #' Should be in same order as attributeNames in the attribute table, or be a named list.
 #' @details The attributes data frame must use only the recognized column
@@ -167,8 +167,8 @@ set_BoundsGroup <- function(row, cls = "BoundsGroup"){
 
 
 infer_domain_scale <- function(col_classes, attributeName = names(col_classes)){
-  if(!(all(col_classes %in% c("numeric", "character", "factor", "Date")))){
-    stop(call. = FALSE, "All col_classes values have to be 'numeric', 'character', 'factor' or 'Date'.")
+  if(!(all(col_classes[!is.na(col_classes)] %in% c("numeric", "character", "factor", "Date", "ordered")))){
+    stop(call. = FALSE, "All non missing col_classes values have to be 'ordered', 'numeric', 'character', 'factor' or 'Date'.")
   }
   domain <- col_classes
   measurementScale <- col_classes

--- a/README.Rmd
+++ b/README.Rmd
@@ -15,6 +15,7 @@ knitr::opts_chunk$set(
 ```
 
 [![Travis-CI Build Status](https://travis-ci.org/ropensci/EML.svg?branch=master)](https://travis-ci.org/ropensci/EML)
+[![codecov.io](https://codecov.io/github/ropensci/EML/coverage.svg?branch=master)](https://codecov.io/github/ropensci/EML?branch=master)
 
 
 # EML: The Ecological Metadata Language Standard

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- README.md is generated from README.Rmd. Please edit that file -->
-[![Travis-CI Build Status](https://travis-ci.org/ropensci/EML.svg?branch=master)](https://travis-ci.org/ropensci/EML)
+[![Travis-CI Build Status](https://travis-ci.org/ropensci/EML.svg?branch=master)](https://travis-ci.org/ropensci/EML) [![codecov.io](https://codecov.io/github/ropensci/EML/coverage.svg?branch=master)](https://codecov.io/github/ropensci/EML?branch=master)
 
 EML: The Ecological Metadata Language Standard
 ==============================================
@@ -103,6 +103,8 @@ Validate EML against the official schema
 ``` r
 # An EML document with no validation errors
 eml_validate(eml)
+#> Warning in is.na(encoding): is.na() applied to non-(list or vector) of type
+#> 'NULL'
 #> [1] TRUE
 
 # An EML document with validation errors

--- a/man/set_attributes.Rd
+++ b/man/set_attributes.Rd
@@ -14,7 +14,8 @@ set_attributes(attributes, factors = NULL, col_classes = NULL)
 
 \item{col_classes}{optional, list of R column classes ('ordered', 'numeric', 'factor', 'Date', or 'character', case sensitive)
 will let the function infer missing 'domain' and 'measurementScale' values for attributes column.
-Should be in same order as attributeNames in the attribute table, or be a named list.}
+Should be in same order as attributeNames in the attributes table, or be a named list with names corresponding to attributeNames
+in the attributes table.}
 }
 \value{
 an eml "attributeList" object

--- a/man/set_attributes.Rd
+++ b/man/set_attributes.Rd
@@ -12,7 +12,7 @@ set_attributes(attributes, factors = NULL, col_classes = NULL)
 
 \item{factors}{a table with factor code-definition pairs; see details}
 
-\item{col_classes}{optional, list of R column classes ('numeric', 'factor', 'Date', or 'character', case sensitive)
+\item{col_classes}{optional, list of R column classes ('ordered', 'numeric', 'factor', 'Date', or 'character', case sensitive)
 will let the function infer missing 'domain' and 'measurementScale' values for attributes column.
 Should be in same order as attributeNames in the attribute table, or be a named list.}
 }

--- a/man/set_attributes.Rd
+++ b/man/set_attributes.Rd
@@ -12,7 +12,7 @@ set_attributes(attributes, factors = NULL, col_classes = NULL)
 
 \item{factors}{a table with factor code-definition pairs; see details}
 
-\item{col_classes}{optional, list of R column classes (numeric, factor, date, character)
+\item{col_classes}{optional, list of R column classes ('numeric', 'factor', 'Date', or 'character', case sensitive)
 will let the function infer missing 'domain' and 'measurementScale' values for attributes column.
 Should be in same order as attributeNames in the attribute table, or be a named list.}
 }

--- a/tests/testthat/test-attributes.R
+++ b/tests/testthat/test-attributes.R
@@ -326,6 +326,8 @@ testthat::test_that("The set_attributes function stops if non permitted values i
       definition = unname(value.i)
     )
   )
+  testthat::expect_error(set_attributes(attributes, factors, col_classes = list(run_numero = "character", year = "Date")))
+  
   testthat::expect_error(set_attributes(attributes, factors, col_classes = c("character", "Date", "Date", "Date", "factor", "factor", "numeric")))
   testthat::expect_error(set_attributes(attributes, factors, col_classes = c("character", "Date", "Date", "Date", "factor", "factor", "lalala", "numeric")))
 })

--- a/tests/testthat/test-attributes.R
+++ b/tests/testthat/test-attributes.R
@@ -224,6 +224,111 @@ testthat::test_that("The set_attributes function stops if missing required field
   testthat::expect_error(set_attributes(attributes))
 })
 
+testthat::test_that("The set_attributes function stops if non permitted values in col_classes", {
+  attributes <-
+    data.frame(
+      attributeName = c(
+        "run.num",
+        "year",
+        "day",
+        "hour.min",
+        "i.flag",
+        "variable",
+        "value.i",
+        "length"), 
+      formatString = c(
+        NA,        
+        "YYYY",     
+        "DDD",      
+        "hhmm",     
+        NA,         
+        NA,         
+        NA,
+        NA),
+      definition = c(        
+        "which run number",
+        NA,
+        NA,
+        NA,
+        NA,
+        NA, 
+        NA,
+        NA),
+      unit = c(
+        NA,
+        NA,
+        NA,
+        NA,
+        NA,
+        NA,
+        NA,
+        "meter"),
+      attributeDefinition = c(
+        "which run number (=block). Range: 1 - 6. (integer)",
+        "year, 2012",
+        "Julian day. Range: 170 - 209.",
+        "hour and minute of observation. Range 1 - 2400 (integer)",
+        "is variable Real, Interpolated or Bad (character/factor)",
+        "what variable being measured in what treatment (character/factor).",
+        "value of measured variable for run.num on year/day/hour.min.",
+        "length of the species in meters (dummy example of numeric data)"),
+      numberType = c(
+        NA,
+        NA,
+        NA,
+        NA,
+        NA,
+        NA,
+        NA,
+        "real"),
+      stringsAsFactors = FALSE
+    )
+  i.flag <- c(R = "real",
+              I = "interpolated",
+              B = "bad")
+  variable <- c(
+    control  = "no prey added",
+    low      = "0.125 mg prey added ml-1 d-1",
+    med.low  = "0,25 mg prey added ml-1 d-1",
+    med.high = "0.5 mg prey added ml-1 d-1",
+    high     = "1.0 mg prey added ml-1 d-1",
+    air.temp = "air temperature measured just above all plants (1 thermocouple)",
+    water.temp = "water temperature measured within each pitcher",
+    par       = "photosynthetic active radiation (PAR) measured just above all plants (1 sensor)"
+  )
+  
+  value.i <- c(
+    control  = "% dissolved oxygen",
+    low      = "% dissolved oxygen",
+    med.low  = "% dissolved oxygen",
+    med.high = "% dissolved oxygen",
+    high     = "% dissolved oxygen",
+    air.temp = "degrees C",
+    water.temp = "degrees C",
+    par      = "micromoles m-1 s-1"
+  )
+  
+  ## Write these into the data.frame format
+  factors <- rbind(
+    data.frame(
+      attributeName = "i.flag",
+      code = names(i.flag),
+      definition = unname(i.flag)
+    ),
+    data.frame(
+      attributeName = "variable",
+      code = names(variable),
+      definition = unname(variable)
+    ),
+    data.frame(
+      attributeName = "value.i",
+      code = names(value.i),
+      definition = unname(value.i)
+    )
+  )
+  testthat::expect_error(set_attributes(attributes, factors, col_classes = c("character", "Date", "Date", "Date", "factor", "factor", "lalala", "numeric")))
+})
+
 testthat::test_that("The set_attributes function returns useful warnings",{
   attributes <- data.frame(attributeName = "date",
                            attributeDefinition = "date",

--- a/tests/testthat/test-attributes.R
+++ b/tests/testthat/test-attributes.R
@@ -224,7 +224,7 @@ testthat::test_that("The set_attributes function stops if missing required field
   testthat::expect_error(set_attributes(attributes))
 })
 
-testthat::test_that("The set_attributes function stops if non permitted values in col_classes", {
+testthat::test_that("The set_attributes function stops if non permitted values in col_classes or wrong length of col_classes", {
   attributes <-
     data.frame(
       attributeName = c(
@@ -326,6 +326,7 @@ testthat::test_that("The set_attributes function stops if non permitted values i
       definition = unname(value.i)
     )
   )
+  testthat::expect_error(set_attributes(attributes, factors, col_classes = c("character", "Date", "Date", "Date", "factor", "factor", "numeric")))
   testthat::expect_error(set_attributes(attributes, factors, col_classes = c("character", "Date", "Date", "Date", "factor", "factor", "lalala", "numeric")))
 })
 


### PR DESCRIPTION
In reference to https://github.com/ropensci/EML/pull/169#issuecomment-228188719

* I added the covr code in .travis.yml and the codecov.io badge in the README.

* Now `col_classes` non missing values are checked if `col_classes` is not NULL. I added an unit test for this.

* I have changed the error message to "attributes table must include an 'domain' column, or you need to input 'col_classes'."
