### PR TITLE
set_attributes + set_coverage

### DIFF
--- a/R/set_attributes.R
+++ b/R/set_attributes.R
@@ -194,18 +194,72 @@ infer_domain_scale <- function(col_classes, attributeName = names(col_classes), 
   domain[col_classes == "character"] <- "textDomain"
   domain[col_classes %in% c("factor", "ordered")] <- "enumeratedDomain"
   domain[col_classes %in% c("Date")] <- "dateTimeDomain"
+  # compare domain with domain given in attributes if there is one
+  if("domain" %in% names(attributes)){
+    if(!is.null(names(col_classes))){
+      if(any(domain != attributes$domain[attributes$attributeName == names(col_classes)])){
+        whichNot <- names(col_classes)[which(domain != attributes$domain[attributes$attributeName == names(col_classes)])]
+        stop(call. = FALSE,
+             paste0( "For the attribute ", whichNot," the domain value inferred from col_classes does not agree with the domain value existing in attributes. Check col_classes and the domain column you provided.\n"))
+      }
+    }else{
+      if(any(domain != attributes$domain)){
+        whichNot <- attributes$attributeName[which(domain != attributes$domain)]
+        stop(call. = FALSE,
+             paste0( "For the attribute ", whichNot," the domain value inferred from col_classes does not agree with the domain value existing in attributes. Check col_classes and the domain column you provided.\n"))
+        
+      }
+    }
+  }
 
   measurementScale[col_classes == "numeric"] <- "ratio" # !
   measurementScale[col_classes == "character"] <- "nominal"
   measurementScale[col_classes == "ordered"] <- "ordinal"
   measurementScale[col_classes == "factor"] <- "nominal"
   measurementScale[col_classes %in% c("Date")] <- "dateTime"
+  
+  # compare measurementScale with measurementScale given in attributes if there is one
+  if("measurementScale" %in% names(attributes)){
+    if(!is.null(names(col_classes))){
+      if(any(measurementScale != attributes$measurementScale[attributes$attributeName == names(col_classes)])){
+        whichNot <- names(col_classes)[which(measurementScale != attributes$measurementScale[attributes$attributeName == names(col_classes)])]
+        stop(call. = FALSE,
+             paste0( "For the attribute ", whichNot," the measurementScale value inferred from col_classes does not agree with the measurementScale value existing in attributes. Check col_classes and the measurementScale column you provided.\n"))
+      }
+    }else{
+      if(any(measurementScale != attributes$measurementScale)){
+        whichNot <- attributes$attributeName[which(measurementScale != attributes$measurementScale)]
+        stop(call. = FALSE,
+             paste0( "For the attribute ", whichNot," the measurementScale value inferred from col_classes does not agree with the measurementScale value existing in attributes. Check col_classes and the measurementScale column you provided.\n"))
+        
+      }
+    }
+  }
+
 
   ## storage type is optional, maybe better not to set this?
   storageType[col_classes == "numeric"] <- "float"
   storageType[col_classes == "character"] <- "string"
   storageType[col_classes %in% c("factor", "ordered")] <- "string"
   storageType[col_classes %in% c("Date")] <- "date"
+  
+  # compare storageType with storageType given in attributes if there is one
+  if("storageType" %in% names(attributes)){
+    if(!is.null(names(col_classes))){
+      if(any(storageType != attributes$storageType[attributes$attributeName == names(col_classes)])){
+        whichNot <- names(col_classes)[which(storageType != attributes$storageType[attributes$attributeName == names(col_classes)])]
+        stop(call. = FALSE,
+             paste0( "For the attribute ", whichNot," the storageType value inferred from col_classes does not agree with the storageType value existing in attributes. Check col_classes and the storageType column you provided.\n"))
+      }
+    }else{
+      if(any(storageType != attributes$storageType)){
+        whichNot <- attributes$attributeName[which(storageType != attributes$storageType)]
+        stop(call. = FALSE,
+             paste0( "For the attribute ", whichNot," the storageType value inferred from col_classes does not agree with the storageType value existing in attributes. Check col_classes and the storageType column you provided.\n"))
+        
+      }
+    }
+  }
 
 
   data.frame(attributeName = attributeName, domain = domain, measurementScale = measurementScale, storageType = storageType, stringsAsFactors = FALSE)

--- a/tests/testthat/test-attributes.R
+++ b/tests/testthat/test-attributes.R
@@ -25,7 +25,7 @@ testthat::test_that("we can have numeric data with bounds where some bounds are 
                    entityDescription = "csv file containing the data", 
                    physical = set_physical("file.csv"))
   
-  me <- as.person("Carl Boettiger <cboettig@gmail.com>")
+  me <- as.person("Carl Boettiger <cboettig@gmail.com> [ctb]")
   dataset <- new("dataset", title = "Example EML", creator = me, contact = me, dataTable = dataTable)
   eml <- new("eml", packageId = "123", system = "uuid", dataset = dataset)
   
@@ -326,11 +326,66 @@ testthat::test_that("The set_attributes function stops if non permitted values i
       definition = unname(value.i)
     )
   )
-  testthat::expect_error(set_attributes(attributes, factors, col_classes = list(run_numero = "character", year = "Date")))
-  
   testthat::expect_error(set_attributes(attributes, factors, col_classes = c("character", "Date", "Date", "Date", "factor", "factor", "numeric")))
   testthat::expect_error(set_attributes(attributes, factors, col_classes = c("character", "Date", "Date", "Date", "factor", "factor", "lalala", "numeric")))
-})
+  
+  attributes <-
+    data.frame(
+      attributeName = c( "run.num", "year", "day"), 
+      formatString = c( NA, "YYYY", "DDD"),
+      definition = c( "which run number", NA, NA),
+      unit = c( NA, NA, NA),
+      attributeDefinition = c(
+        "which run number (=block). Range: 1 - 6. (integer)",
+        "year, 2012",
+        "Julian day. Range: 170 - 209."),
+      numberType = c( NA, NA, NA),
+      domain = c("numericDomain", "numericDomain", "numericDomain"),
+      measurementScale = c("ratio", "nominal", "interval"),
+      stringsAsFactors = FALSE
+    )
+  testthat::expect_error(set_attributes(attributes, col_classes = list(run_numero = "character", year = "Date")))
+  testthat::expect_error(set_attributes(attributes, col_classes = list(run.num = "Date", year = "Date", day = "Date")))
+  testthat::expect_error(set_attributes(attributes, col_classes = list("Date", "Date", "Date")))
+  
+  attributes <-
+    data.frame(
+      attributeName = c( "run.num", "year", "day"), 
+      formatString = c( NA, "YYYY", "DDD"),
+      definition = c( "which run number", NA, NA),
+      unit = c( NA, NA, NA),
+      attributeDefinition = c(
+        "which run number (=block). Range: 1 - 6. (integer)",
+        "year, 2012",
+        "Julian day. Range: 170 - 209."),
+      numberType = c( NA, NA, NA),
+      measurementScale = c("ratio", "nominal", "interval"),
+      stringsAsFactors = FALSE
+    )
+  testthat::expect_error(set_attributes(attributes, col_classes = list(run.num = "numeric", year = "Date", day = "Date")))
+  
+  testthat::expect_error(set_attributes(attributes, col_classes = list("Date", "Date", "Date")))
+  
+  attributes <-
+    data.frame(
+      attributeName = c( "run.num", "year", "day"), 
+      formatString = c( NA, "YYYY", "DDD"),
+      definition = c( "which run number", NA, NA),
+      unit = c( NA, NA, NA),
+      attributeDefinition = c(
+        "which run number (=block). Range: 1 - 6. (integer)",
+        "year, 2012",
+        "Julian day. Range: 170 - 209."),
+      numberType = c( NA, NA, NA),
+      storageType = c("float", "float", "float"),
+      stringsAsFactors = FALSE
+    )
+  testthat::expect_error(set_attributes(attributes, col_classes = list(run.num = "numeric", year = "Date", day = "Date")))
+  
+  testthat::expect_error(set_attributes(attributes, col_classes = list("Date", "Date", "Date")))
+  
+  
+  })
 
 testthat::test_that("The set_attributes function returns useful warnings",{
   attributes <- data.frame(attributeName = "date",

--- a/tests/testthat/test-coverage.R
+++ b/tests/testthat/test-coverage.R
@@ -12,4 +12,16 @@ testthat::test_that("set_coverage creates a coverage object",{
                  altitudeUnits = "meter")
   
   testthat::expect_is(coverage, "coverage")
+  
+  
+  coverage <- 
+    set_coverage(date = as.character(seq(from = as.Date("1970-01-01"), length = 56, by = "1 week")),
+                 sci_names = "Sarracenia purpurea",
+                 geographicDescription = geographicDescription,
+                 west = -122.44, east = -117.15, 
+                 north = 37.38, south = 30.00,
+                 altitudeMin = 160, altitudeMaximum = 330,
+                 altitudeUnits = "meter")
+  
+  testthat::expect_is(coverage, "coverage")
   })


### PR DESCRIPTION
* as discussed [here](https://github.com/ropensci/EML/pull/169#issuecomment-228741734) I added an error for when the users provides `domain` / `measurementScale` / `storageType` in `attributes & `col_classes` and the function infers different values. However, the code is ugly and most importantly I'm not sure whether the error message is very clear?

* I added a test for `set_coverage` and started wondering whether the arguments `begin`, `end` and `date` should be documented more precisely (order of the year/month/date, separator) or whether they could be inputted as dates instead. I have opened an issue https://github.com/ropensci/EML/issues/172