### PR TITLE
Some minor changes to set_taxonomicCovergae

### DIFF
--- a/R/set_coverage.R
+++ b/R/set_coverage.R
@@ -150,7 +150,7 @@ set_taxonomicCoverage <- function(sci_names){
     new("taxonomicCoverage",
         taxonomicClassification = do.call(c, taxa))
   } else if (class(sci_names)=="data.frame"){
-    taxon_classification = list("Kingdom","Phylum","Class","Order","Family","Genus","genusSpecies","Common")
+    taxon_classification = list("Kingdom","Phylum","Class","Order","Family","Genus","Species","Common")
     ColNames = colnames(sci_names)
     taxa = lapply(taxon_classification, function(name){
       index = grep(name, ColNames, ignore.case = TRUE)

--- a/R/set_coverage.R
+++ b/R/set_coverage.R
@@ -20,12 +20,10 @@
 #'
 #' @return a coverage object for EML
 #' 
-#' @note If "sci_names" is a data frame, a certain order of rank names is expected: 
-#' "Kingdom","Phylum","Class","Order","Family","Genus","genusSpecies","Common". The function
-#' will look for keywords from column names of the data frame. Rank names other than these 
-#' eight names will be ignored. The data frame do not necessarily to contain all the eight
-#' rank names. If "sci_names" is a list, users must make sure that the order of rank names
-#' they specify is from high to low.
+#' @note If "sci_names" is a data frame, column names of the data frame are rank names.
+#' For user-defined "sci_names", users must make sure that the order of rank names
+#' they specify is from high to low. 
+#' Ex. "Kingdom","Phylum","Class","Order","Family","Genus","Species","Common"
 #' 
 #' @export
 #'
@@ -116,12 +114,11 @@ set_temporalCoverage <- function(beginDate = character(), endDate  = character()
 #' or a list of user-defined taxonomicClassification
 #' 
 #' @return a taxonomicCoverage object for EML
-#' @note If "sci_names" is a data frame, a certain order of rank names is expected: 
-#' "Kingdom","Phylum","Class","Order","Family","Genus","genusSpecies","Common". The function
-#' will look for keywords from column names of the data frame. Rank names other than these 
-#' eight names will be ignored. The data frame do not necessarily to contain all the eight
-#' rank names. If "sci_names" is a list, users must make sure that the order of rank names
-#' they specify is from high to low.
+#' @note If "sci_names" is a data frame, column names of the data frame are rank names.
+#' For user-defined "sci_names", users must make sure that the order of rank names
+#' they specify is from high to low. 
+#' Ex. "Kingdom","Phylum","Class","Order","Family","Genus","Species","Common"
+#' 
 #' @export
 #'
 #' @examples 
@@ -150,19 +147,14 @@ set_taxonomicCoverage <- function(sci_names){
     new("taxonomicCoverage",
         taxonomicClassification = do.call(c, taxa))
   } else if (class(sci_names)=="data.frame"){
-    taxon_classification = list("Kingdom","Phylum","Class","Order","Family","Genus","Species","Common")
-    ColNames = colnames(sci_names)
+    taxon_classification = colnames(sci_names)
     new = as.data.frame(t(sci_names))
     colnames(new) = NULL
     taxa = lapply(new, function(sci_name){
         tc = lapply(taxon_classification, function(name){
-        index = grep(name, ColNames, ignore.case = TRUE)
-        if (length(index)!=0){
-          index = index[1]
           new("taxonomicClassification",
-              taxonRankName = ColNames[index],
-              taxonRankValue = as.character(sci_name[index]))
-        }
+              taxonRankName = name,
+              taxonRankValue = as.character(sci_name[name]))
         })
         tc = formRecursiveTree(tc)[[1]]
     })

--- a/R/set_coverage.R
+++ b/R/set_coverage.R
@@ -179,7 +179,7 @@ set_taxonomicCoverage <- function(sci_names){
     new("taxonomicCoverage",
         taxonomicClassification = do.call(c, taxa))
   } else {
-    stop("Incorrect format: sci_names can only be data.frame or list")
+    stop("Incorrect format: sci_names can only be character string, data.frame or list")
   }
 } 
 

--- a/R/set_coverage.R
+++ b/R/set_coverage.R
@@ -152,16 +152,20 @@ set_taxonomicCoverage <- function(sci_names){
   } else if (class(sci_names)=="data.frame"){
     taxon_classification = list("Kingdom","Phylum","Class","Order","Family","Genus","Species","Common")
     ColNames = colnames(sci_names)
-    taxa = lapply(taxon_classification, function(name){
-      index = grep(name, ColNames, ignore.case = TRUE)
-      if (length(index)!=0){
-        index = index[1]
-        new("taxonomicClassification",
-            taxonRankName = ColNames[index],
-            taxonRankValue = as.character(sci_names[1,index]))
-      }
+    new = as.data.frame(t(sci_names))
+    colnames(new) = NULL
+    taxa = lapply(new, function(sci_name){
+        tc = lapply(taxon_classification, function(name){
+        index = grep(name, ColNames, ignore.case = TRUE)
+        if (length(index)!=0){
+          index = index[1]
+          new("taxonomicClassification",
+              taxonRankName = ColNames[index],
+              taxonRankValue = as.character(sci_name[index]))
+        }
+        })
+        tc = formRecursiveTree(tc)[[1]]
     })
-    taxa = formRecursiveTree(taxa)
     new("taxonomicCoverage",
         taxonomicClassification = do.call(c, taxa))
   } else if (class(sci_names)=="list"){

--- a/man/set_coverage.Rd
+++ b/man/set_coverage.Rd
@@ -50,12 +50,10 @@ well suited, and users will need the more flexible but more verbose construction
 of calendar dates, or to specify taxonomic coverage in terms of other ranks or identifiers.
 }
 \note{
-If "sci_names" is a data frame, a certain order of rank names is expected: 
-"Kingdom","Phylum","Class","Order","Family","Genus","genusSpecies","Common". The function
-will look for keywords from column names of the data frame. Rank names other than these 
-eight names will be ignored. The data frame do not necessarily to contain all the eight
-rank names. If "sci_names" is a list, users must make sure that the order of rank names
-they specify is from high to low.
+If "sci_names" is a data frame, column names of the data frame are rank names.
+For user-defined "sci_names", users must make sure that the order of rank names
+they specify is from high to low. 
+Ex. "Kingdom","Phylum","Class","Order","Family","Genus","Species","Common"
 }
 \examples{
 coverage <- 

--- a/man/set_taxonomicCoverage.Rd
+++ b/man/set_taxonomicCoverage.Rd
@@ -21,12 +21,10 @@ sci_names can be a space-separated character string or a data frame with column 
 or a list of user-defined taxonomicClassification
 }
 \note{
-If "sci_names" is a data frame, a certain order of rank names is expected: 
-"Kingdom","Phylum","Class","Order","Family","Genus","genusSpecies","Common". The function
-will look for keywords from column names of the data frame. Rank names other than these 
-eight names will be ignored. The data frame do not necessarily to contain all the eight
-rank names. If "sci_names" is a list, users must make sure that the order of rank names
-they specify is from high to low.
+If "sci_names" is a data frame, column names of the data frame are rank names.
+For user-defined "sci_names", users must make sure that the order of rank names
+they specify is from high to low. 
+Ex. "Kingdom","Phylum","Class","Order","Family","Genus","Species","Common"
 }
 \examples{
 taxon_coverage <- 

--- a/tests/testthat/test-coverage.R
+++ b/tests/testthat/test-coverage.R
@@ -76,32 +76,6 @@ testthat::test_that("set_taxonomicCoverage create a object with correct depth", 
     taxon = taxon@taxonomicClassification[[1]]
   }
   testthat::expect_equal(depth, 8)
-  
-  # unexpected input in data frame. 
-  dt = data.frame(KINGDOM="Plantae", PHYLUM="Phaeophyta", 
-                  CLASS="Phaeophyceae",ORDER="Laminariales",
-                  FAMILY="Lessoniaceae",GENUS="Macrocystis",
-                  genusSpecies="Macrocystis pyrifera",commonName="MAPY", temp = "nothing")
-  taxon = set_taxonomicCoverage(dt)
-  depth = 0
-  while (length(taxon@taxonomicClassification) > 0){
-    depth = depth + 1
-    taxon = taxon@taxonomicClassification[[1]]
-  }
-  testthat::expect_equal(depth, 8)
-  
-  # input only some of the eight rank names
-  dt = data.frame(PHYLUM="Phaeophyta", 
-                  CLASS="Phaeophyceae",ORDER="Laminariales",
-                  FAMILY="Lessoniaceae",GENUS="Macrocystis",
-                  commonName="MAPY")
-  taxon = set_taxonomicCoverage(dt)
-  depth = 0
-  while (length(taxon@taxonomicClassification) > 0){
-    depth = depth + 1
-    taxon = taxon@taxonomicClassification[[1]]
-  }
-  testthat::expect_equal(depth, 6)
 })
 
 testthat::test_that("set_taxonomicCoverage create valid EML",{


### PR DESCRIPTION
modify set_taxonomicCoverage to handle a data.frame with multiple rows (species). Previous one assumes that the input data frame only has one row (species).