### PR TITLE
Fix a bug in eml_get

### DIFF
--- a/R/eml_get.R
+++ b/R/eml_get.R
@@ -30,7 +30,7 @@
 setGeneric("eml_get", function(x, element = NULL, ...) {
   if (is.null(element)) {
     out <- x
-    
+
   } else {
     all <- eml_find(x, element)
     if (length(all) > 1) {
@@ -40,6 +40,12 @@ setGeneric("eml_get", function(x, element = NULL, ...) {
     } else {
       out <- eml_get(all, ...)
     }
+
+    # Return early if no elements were found
+    if (length(out) == 0) {
+      return(out)
+    }
+
     if (isS4(out) &&
         length(out) < 1)
       # Already a simple S4 element, ready to return

--- a/tests/testthat/test-eml_get.R
+++ b/tests/testthat/test-eml_get.R
@@ -26,3 +26,9 @@ testthat::test_that("we can get child elements from arbitrary nodes", {
   eml_get(eml, "geographicDescription")  #return NULL
 
 })
+
+
+testthat::test_that("an empty list is returned when on elements are found", {
+  empty_eml <- new("eml")
+  testthat::expect_identical(eml_get(empty_eml, "creator"), list())
+})


### PR DESCRIPTION
The old version of this function wasn't handling the case where
the element being searched for wasn't found. The new function
returns an empty list in this case rather than an error.

Closes #190