### PR TITLE
Add support for auto-expanding taxonomic coverage and some minor fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,8 @@ Suggests:
     knitr,
     rmarkdown,
     listviewer,
-    covr
+    covr,
+    taxize
 VignetteBuilder: knitr
 Encoding: UTF-8
 Collate: 

--- a/R/set_coverage.R
+++ b/R/set_coverage.R
@@ -169,7 +169,7 @@ set_temporalCoverage <-
 #' taxon_coverage <- set_taxonomicCoverage(df)
 #'
 #' # Query ITIS using taxize to fill in the full taxonomy given just species
-#' # names
+#  # names
 #' taxon_coverage <- set_taxonomicCoverage(
 #'   c("Macrocystis pyrifera", "Homo sapiens"),
 #'   expand = TRUE)

--- a/R/set_coverage.R
+++ b/R/set_coverage.R
@@ -156,8 +156,7 @@ set_temporalCoverage <-
 #'                             ORDER="Laminariales",
 #'                             FAMILY="Lessoniaceae",
 #'                             GENUS="Macrocystis",
-#'                             genusSpecies="Macrocystis pyrifera",
-#'                             commonName="MAPY"))
+#'                             SPECIES="Macrocystis pyrifera"))
 #'
 #' df <- data.frame(KINGDOM="Plantae",
 #'                  PHYLUM="Phaeophyta",
@@ -165,8 +164,7 @@ set_temporalCoverage <-
 #'                  ORDER="Laminariales",
 #'                  FAMILY="Lessoniaceae",
 #'                  GENUS="Macrocystis",
-#'                  genusSpecies="Macrocystis pyrifera",
-#'                  commonName="MAPY")
+#'                  SPECIES="Macrocystis pyrifera")
 #' taxon_coverage <- set_taxonomicCoverage(df)
 #'
 #' # Query ITIS using taxize to fill in the full taxonomy given just species

--- a/R/set_coverage.R
+++ b/R/set_coverage.R
@@ -136,6 +136,7 @@ set_temporalCoverage <-
 #' set_taxonomicCoverage
 #'
 #' @param sci_names string (space seperated) or list or data frame of scientific names for species covered.
+#' @param expand Set to TRUE to use taxize to expand sci_names into full taxonomic classifications
 #' @details Turn a data.frame or a list of scientific names into a taxonomicCoverage block
 #' sci_names can be a space-separated character string or a data frame with column names as rank name
 #' or a list of user-defined taxonomicClassification

--- a/R/set_coverage.R
+++ b/R/set_coverage.R
@@ -182,7 +182,7 @@ set_taxonomicCoverage <- function(sci_names) {
           new(
             "taxonomicClassification",
             taxonRankName = "species",
-            taxonRankValue = s[[2]]
+            taxonRankValue = sci_name
           )
         )
       )

--- a/man/set_taxonomicCoverage.Rd
+++ b/man/set_taxonomicCoverage.Rd
@@ -36,7 +36,7 @@ taxon_coverage <-
                             ORDER="Laminariales",
                             FAMILY="Lessoniaceae",
                             GENUS="Macrocystis",
-                            genusSpecies="Macrocystis pyrifera"))
+                            SPECIES="Macrocystis pyrifera"))
 
 df <- data.frame(KINGDOM="Plantae",
                  PHYLUM="Phaeophyta",
@@ -48,7 +48,6 @@ df <- data.frame(KINGDOM="Plantae",
 taxon_coverage <- set_taxonomicCoverage(df)
 
 # Query ITIS using taxize to fill in the full taxonomy given just species
-# names
 taxon_coverage <- set_taxonomicCoverage(
   c("Macrocystis pyrifera", "Homo sapiens"),
   expand = TRUE)

--- a/man/set_taxonomicCoverage.Rd
+++ b/man/set_taxonomicCoverage.Rd
@@ -8,6 +8,8 @@ set_taxonomicCoverage(sci_names, expand = FALSE)
 }
 \arguments{
 \item{sci_names}{string (space seperated) or list or data frame of scientific names for species covered.}
+
+\item{expand}{Set to TRUE to use taxize to expand sci_names into full taxonomic classifications}
 }
 \value{
 a taxonomicCoverage object for EML

--- a/man/set_taxonomicCoverage.Rd
+++ b/man/set_taxonomicCoverage.Rd
@@ -4,7 +4,7 @@
 \alias{set_taxonomicCoverage}
 \title{set_taxonomicCoverage}
 \usage{
-set_taxonomicCoverage(sci_names)
+set_taxonomicCoverage(sci_names, expand = FALSE)
 }
 \arguments{
 \item{sci_names}{string (space seperated) or list or data frame of scientific names for species covered.}
@@ -46,5 +46,11 @@ df <- data.frame(KINGDOM="Plantae",
                  genusSpecies="Macrocystis pyrifera",
                  commonName="MAPY")
 taxon_coverage <- set_taxonomicCoverage(df)
+
+# Query ITIS using taxize to fill in the full taxonomy given just species
+# names
+taxon_coverage <- set_taxonomicCoverage(
+  c("Macrocystis pyrifera", "Homo sapiens"),
+  expand = TRUE)
 
 }

--- a/man/set_taxonomicCoverage.Rd
+++ b/man/set_taxonomicCoverage.Rd
@@ -34,8 +34,7 @@ taxon_coverage <-
                             ORDER="Laminariales",
                             FAMILY="Lessoniaceae",
                             GENUS="Macrocystis",
-                            genusSpecies="Macrocystis pyrifera",
-                            commonName="MAPY"))
+                            genusSpecies="Macrocystis pyrifera"))
 
 df <- data.frame(KINGDOM="Plantae",
                  PHYLUM="Phaeophyta",
@@ -43,8 +42,7 @@ df <- data.frame(KINGDOM="Plantae",
                  ORDER="Laminariales",
                  FAMILY="Lessoniaceae",
                  GENUS="Macrocystis",
-                 genusSpecies="Macrocystis pyrifera",
-                 commonName="MAPY")
+                 SPECIES="Macrocystis pyrifera")
 taxon_coverage <- set_taxonomicCoverage(df)
 
 # Query ITIS using taxize to fill in the full taxonomy given just species


### PR DESCRIPTION
- Adds support for expanding taxonomic coverage in `set_taxonomicCoverage` using the `expand=TRUE` argument. This functionality tries to use the `taxize` package to query ITIS for the full taxonomy.
- Fixes some minor issues with the examples for `set_taxonomicCoverage`. `commonName` and `genusSpecies` were being used as taxon rank names but `genusSpecies` should just be 'Species' and commonName is not a rank value but a third attribute of taxonomicClassification. I think more work is needed to support commonNames.