### PR TITLE
makes eml_view work?

### DIFF
--- a/R/eml_view.R
+++ b/R/eml_view.R
@@ -30,7 +30,19 @@ eml_view <- function(eml_path, ...){
   doc <- read_xml(eml_path, ...)
   eml_list <- xml2::as_list(doc)
 
+  # no unnamed elements please
+  if (any(names(eml_list)=="")){
+    names(eml_list)[names(eml_list) == ""] <- "noname"
+  }
+
+  eml_list <- name_all(eml_list)
+
   ## shouldn't call function from a Suggested package, see get_TextType for how we use rmarkdown fns
   jsonedit <- getExportedValue("listviewer", "jsonedit")
-  # jsonedit(eml_list)
+  jsonedit(eml_list)
+}
+
+# code adapted from https://stackoverflow.com/questions/29818918/looping-nested-lists-in-r
+name_all <- function(l){
+  lapply(l, function(x) if(is.list(x) && any(names(x)=="")) names(x)[names(x) == ""] <- "noname" else if(is.list(x)) foo(x) else x)
 }

--- a/R/eml_view.R
+++ b/R/eml_view.R
@@ -44,5 +44,12 @@ eml_view <- function(eml_path, ...){
 
 # code adapted from https://stackoverflow.com/questions/29818918/looping-nested-lists-in-r
 name_all <- function(l){
-  lapply(l, function(x) if(is.list(x) && any(names(x)=="")) names(x)[names(x) == ""] <- "noname" else if(is.list(x)) foo(x) else x)
+  lapply(l, function(x){
+    if(is.list(x) && any(names(x)=="")){
+      names(x)[names(x) == ""] <- "noname"
+      x
+    }  else{
+      if(is.list(x)) name_all(x) else x
+    }
+  } )
 }

--- a/tests/testthat/test-view.R
+++ b/tests/testthat/test-view.R
@@ -1,29 +1,29 @@
-# testthat::context("Viewing EML documents")
-#
-# testthat::test_that("The function doesn't fail", {
-#   if (!requireNamespace("listviewer", quietly = TRUE)) {
-#     f <- system.file("xsd/test", "eml-datasetWithUnits.xml", package = "EML")
-#     testthat::expect_null(eml_view(f))
-#     f <- system.file("xsd/test", "eml.xml", package = "EML")
-#     testthat::expect_null(eml_view(f))
-#     f <- system.file("xsd/test", "eml-sample.xml", package = "EML")
-#     testthat::expect_null(eml_view(f))
-#     f <- system.file("xsd/test", "eml-datasetWithCitation.xml", package = "EML")
-#     testthat::expect_null(eml_view(f))
-#     f <- system.file("examples", "example-eml-2.1.0.xml", package = "EML")
-#     testthat::expect_null(eml_view(f))
-#   }else{
-#     f <- system.file("xsd/test", "eml-datasetWithUnits.xml", package = "EML")
-#     testthat::expect_is(eml_view(f), "jsonedit")
-#     f <- system.file("xsd/test", "eml.xml", package = "EML")
-#     testthat::expect_is(eml_view(f), "jsonedit")
-#     f <- system.file("xsd/test", "eml-sample.xml", package = "EML")
-#     testthat::expect_is(eml_view(f), "jsonedit")
-#     f <- system.file("xsd/test", "eml-datasetWithCitation.xml", package = "EML")
-#     testthat::expect_is(eml_view(f), "jsonedit")
-#     f <- system.file("examples", "example-eml-2.1.0.xml", package = "EML")
-#     testthat::expect_is(eml_view(f), "jsonedit")
-#
-#   }
-#
-# })
+testthat::context("Viewing EML documents")
+
+testthat::test_that("The function doesn't fail", {
+  if (!requireNamespace("listviewer", quietly = TRUE)) {
+    f <- system.file("xsd/test", "eml-datasetWithUnits.xml", package = "EML")
+    testthat::expect_null(eml_view(f))
+    f <- system.file("xsd/test", "eml.xml", package = "EML")
+    testthat::expect_null(eml_view(f))
+    f <- system.file("xsd/test", "eml-sample.xml", package = "EML")
+    testthat::expect_null(eml_view(f))
+    f <- system.file("xsd/test", "eml-datasetWithCitation.xml", package = "EML")
+    testthat::expect_null(eml_view(f))
+    f <- system.file("examples", "example-eml-2.1.0.xml", package = "EML")
+    testthat::expect_null(eml_view(f))
+  }else{
+    f <- system.file("xsd/test", "eml-datasetWithUnits.xml", package = "EML")
+    testthat::expect_is(eml_view(f), "jsonedit")
+    f <- system.file("xsd/test", "eml.xml", package = "EML")
+    testthat::expect_is(eml_view(f), "jsonedit")
+    f <- system.file("xsd/test", "eml-sample.xml", package = "EML")
+    testthat::expect_is(eml_view(f), "jsonedit")
+    f <- system.file("xsd/test", "eml-datasetWithCitation.xml", package = "EML")
+    testthat::expect_is(eml_view(f), "jsonedit")
+    f <- system.file("examples", "example-eml-2.1.0.xml", package = "EML")
+    testthat::expect_is(eml_view(f), "jsonedit")
+
+  }
+
+})


### PR DESCRIPTION
cf https://github.com/ropensci/EML/issues/189

@cboettig @amoeba this is a sort of dirty fix, the `jsonedit` function (and its `xmlview` equivalent anyway) doesn't accept unnamed elements in the nested list. Therefore I recursively name all elements, replacing "" names with "noname". E.g. 

```r
f <- system.file("xsd/test", "eml-datasetWithUnits.xml", package = "EML")
eml_view(f)
```
The unnamed element is "[ comment ]" which has no name and is an element of additionalMetadata$metadata$unitList.

* Not sure it's a very good way to handle this.

* I adapted code from SO, what does that mean for the license? It was easier than figuring out on my own how to look at all depths of the list if some elements were unnamed. :see_no_evil: 