### PR TITLE
Fix up get_TextType

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * `set_taxonomicCoverage` now supports expanding the provided species names into full taxonomic classifications via the taxize package
 * Fixed two bugs in `get_TextType` which were preventing the method from working under multiple scenarios
+* Improved `eml_view` so it works when there are XML comments in the EML record being viewed
+* Added the ability to `set_physical` to calculate file size and checksums automatically
 
 # EML 1.0.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # EML 1.0.4
 
 * `set_taxonomicCoverage` now supports expanding the provided species names into full taxonomic classifications via the taxize package
+* Fixed two bugs in `get_TextType` which were preventing the method from working under multiple scenarios
 
 # EML 1.0.3
 

--- a/R/get_TextType.R
+++ b/R/get_TextType.R
@@ -61,7 +61,8 @@ get_TextType <-
       xml2::xml_new_root(xml2::xml_dtd("section",
                        "-//OASIS//DTD DocBook XML V4.2//EN",
                        "http://oasis-open.org/docbook/xml/4.5/docbookx.dtd"))
-    xml2::xml_add_child(doctype, "article")
+    article_el <- xml2::xml_add_child(doctype, "article")
+    lapply(x, function(node) { xml2::xml_add_child(article_el, node)})
     xml2::write_xml(doctype, docbook_file)
     pandoc_convert(
       basename(docbook_file),
@@ -71,14 +72,8 @@ get_TextType <-
       options = "-s"
     )
 
-    file.copy(output, file.path(wd, basename(output)), overwrite = TRUE)
-
-
-    setwd(wd)
-
     if (view && to == "html")
       utils::browseURL(basename(output))
 
-
-
+    output
   }

--- a/R/get_TextType.R
+++ b/R/get_TextType.R
@@ -42,7 +42,7 @@ get_TextType <-
       node <- node[[1]]
 
     # serialize sections in ListOfsection or paras from ListOfpara into XML document, save, rmarkdown into desired format
-    x <- xml2::xml_children(s4_to_xml(node, root = xml2::xml_new_root("root")))
+    x <- xml2::xml_contents(EML:::s4_to_xml(node, root = xml2::xml_new_root("root")))
 
     if (!requireNamespace("rmarkdown", quietly = TRUE)) {
       stop("rmarkdown package required to convert to Docbook format",

--- a/R/get_TextType.R
+++ b/R/get_TextType.R
@@ -3,7 +3,7 @@
 
 #' get_TextType
 #'
-#' Render a TextType node int HTML or some other format
+#' Render a TextType node into HTML or some other format
 #'
 #' @param node any TextType node
 #' @param to desired format, default is html, but can be any type supported by pandoc (docx, md, etc)

--- a/R/get_TextType.R
+++ b/R/get_TextType.R
@@ -48,6 +48,7 @@ get_TextType <-
       stop("rmarkdown package required to convert to Docbook format",
            call. = FALSE)
     }
+
     pandoc_convert <-
       getExportedValue("rmarkdown", "pandoc_convert")
 
@@ -63,7 +64,9 @@ get_TextType <-
                        "http://oasis-open.org/docbook/xml/4.5/docbookx.dtd"))
     article_el <- xml2::xml_add_child(doctype, "article")
     lapply(x, function(node) { xml2::xml_add_child(article_el, node)})
+
     xml2::write_xml(doctype, docbook_file)
+
     pandoc_convert(
       basename(docbook_file),
       to = to,

--- a/tests/testthat/test-TextType.R
+++ b/tests/testthat/test-TextType.R
@@ -71,3 +71,20 @@ testthat::test_that(
  unlink("abstract.markdown") # tidy up
 
   })
+
+testthat::test_that(
+  "We can parse a simple abstract into markdown withour errors",
+  {
+    skip_on_cran()
+    #skip_on_appveyor()
+    #skip_on_os("windows")
+
+    abstract <- as("Test abstract", "abstract")
+    get_TextType(abstract, "markdown", "abstract.markdown")
+    a <- readLines("abstract.markdown")
+
+    testthat::expect_match(a, "Test abstract")
+
+    unlink("abstract.markdown") # tidy up
+
+  })


### PR DESCRIPTION
This PR addresses and closes two Issues with `get_TextType`

https://github.com/ropensci/EML/issues/229
https://github.com/ropensci/EML/issues/230

`get_TextType` should work nicely now with simple and complex cases.
