### PR TITLE
get attributes bug fix for NULL data frames

### DIFF
--- a/R/get_attributes.R
+++ b/R/get_attributes.R
@@ -282,19 +282,24 @@ choice <- function(s4) {
 ## merge a list of data frames
 merge_df <- function(list_of_df) {
   x <- list_of_df
+  df <- NULL  # returns NULL if no attributes exist
 
   null_indices <- which(unlist(lapply(x, function(a) {is.null(a)})))
   if (length(null_indices) > 0) {
-  x <- x[-null_indices]
+    x <- x[-null_indices]
   }
 
   n_df <- length(x)
-  df <- x[[1]]
+  index = 1
 
-  index = 2
   while (index <= n_df) {
-    df <- merge(df, x[[index]], all = TRUE)
-    index <- index + 1
+    if (index == 1) {  # problem with else statement
+      df <- x[[1]]
+      index <- index + 1
+    } else {
+      df <- merge(df, x[[index]], all = TRUE)
+      index <- index + 1
+    }
   }
 
   return(df)

--- a/R/get_attributes.R
+++ b/R/get_attributes.R
@@ -32,8 +32,8 @@ get_attributes <- function(x, eml = x) {
   datetimes <- datetime_attributes(A, eml)
   factors <- factor_attributes(A, eml)
 
-  attr_table <-
-    merge(merge(merge(numerics, datetimes, all = TRUE), chars, all = TRUE), column_meta, all = TRUE)
+  attr_list <- list(numerics, datetimes, chars, column_meta, factors)
+  attr_table <- merge_df(attr_list)
 
   # restore original order of attributes
   row.names(attr_table) <- attr_table$attributeName
@@ -277,4 +277,19 @@ choice <- function(s4) {
   drop <- sapply(who, function(x)
     isEmpty(slot(s4, x)))
   who[!drop]
+}
+
+## define merging two data frames as function for call in 'merge_df'
+merge_two_df <- function(x,y) {
+  merge(x, y, all = TRUE)
+}
+
+## merge a list of data frames
+merge_df <- function(list_of_df) {
+  x <- list_of_df
+
+  null_indices <- which(unlist(lapply(x, function(a) {is.null(a)})))
+  x <- x[-null_indices]
+
+  data.frame(tail(lapply(x, merge_two_df, x[[1]]), n=1))
 }

--- a/R/get_attributes.R
+++ b/R/get_attributes.R
@@ -32,7 +32,7 @@ get_attributes <- function(x, eml = x) {
   datetimes <- datetime_attributes(A, eml)
   factors <- factor_attributes(A, eml)
 
-  attr_list <- list(numerics, datetimes, chars, column_meta, factors)
+  attr_list <- list(numerics, datetimes, chars, column_meta)
   attr_table <- merge_df(attr_list)
 
   # restore original order of attributes
@@ -279,17 +279,23 @@ choice <- function(s4) {
   who[!drop]
 }
 
-## define merging two data frames as function for call in 'merge_df'
-merge_two_df <- function(x,y) {
-  merge(x, y, all = TRUE)
-}
-
 ## merge a list of data frames
 merge_df <- function(list_of_df) {
   x <- list_of_df
 
   null_indices <- which(unlist(lapply(x, function(a) {is.null(a)})))
+  if (length(null_indices) > 0) {
   x <- x[-null_indices]
+  }
 
-  data.frame(tail(lapply(x, merge_two_df, x[[1]]), n=1))
+  n_df <- length(x)
+  df <- x[[1]]
+
+  index = 2
+  while (index <= n_df) {
+    df <- merge(df, x[[index]], all = TRUE)
+    index <- index + 1
+  }
+
+  return(df)
 }


### PR DESCRIPTION
I found a "bug" when using `get_attributes` to extract attribute metadata from packages on the Arctic Data Center.  It occurs when one or more of the data frames extracted by the following code in `get_attributes` is `NULL`.  I hesitate to call it a bug because it won't occur when working with a high quality EML.  But I think this is useful as it allows you extract attribute metadata from lower quality EMLs.  

Error occurs if one or more of the following calls returns `NULL`
```
column_meta <- column_attributes(A)
numerics <- numeric_attributes(A, eml)
chars <- char_attributes(A, eml)
datetimes <- datetime_attributes(A, eml)
factors <- factor_attributes(A, eml)
```
For instance if `datetimes` is `NULL` then the initial merge (below) in the following call doesn't merge properly.  The function still returns a data.table, but all the information in `numerics` is lost.
```
attr_table <-
merge(merge(merge(numerics, datetimes, all = TRUE), chars, all = TRUE), column_meta, all = TRUE)
```

Couple additional notes: 
`devtools::check()` returned a few errors, but I don't think any were related to my branch (I hope!). 

I also noticed a few missing cases of `xml2::` in the various functions called by `get_attributes` that I had to correct before my updated version of `get_attributes` would run locally.  I'd be happy to add these to the PR if you'd like.  

Please let me know what you think, I'd be happy to make any changes / suggestions!



