### PR TITLE
fix bug in `set_physical` if file is not on disk

### DIFF
--- a/R/set_physical.R
+++ b/R/set_physical.R
@@ -121,7 +121,7 @@ set_physical <- function(objectName,
 #'
 #' @return (character) If found, the delimiter, it not, \\r\\n
 detect_delim <- function(path, nchar = 1e3) {
-  # only check if the file exists
+  # only look for delimiter if the file exists
   if(file.exists(path)){
     # readChar() will error on non-character data so
     chars <- tryCatch({

--- a/R/set_physical.R
+++ b/R/set_physical.R
@@ -121,20 +121,25 @@ set_physical <- function(objectName,
 #'
 #' @return (character) If found, the delimiter, it not, \\r\\n
 detect_delim <- function(path, nchar = 1e3) {
-   # readChar() will error on non-character data so
-  chars <- tryCatch({
-    readChar(path, nchar)
-  },
-  error = function(e) {
-    NA
-  })
-
-  search <- regexpr("[\\r\\n]+", chars, perl = TRUE)
-
-  if (!is.na(search) && search >= 0) {
-    return(substr(chars, search, search + attr(search, "match.length") - 1))
+  # only check if the file exists
+  if(file.exists(path)){
+    # readChar() will error on non-character data so
+    chars <- tryCatch({
+      readChar(path, nchar)
+    },
+    error = function(e) {
+      NA
+    })
+    
+    search <- regexpr("[\\r\\n]+", chars, perl = TRUE)
+    
+    if (!is.na(search) && search >= 0) {
+      return(substr(chars, search, search + attr(search, "match.length") - 1))
+    }
   }
-
+  # readChar() will error on non-character data so
+  
+  
   "\r\n"
 }
 


### PR DESCRIPTION
`set_physical` has a check in place to make sure that the function won't try to read in a file that doesn't exist, but `detect_delim` does not. This causes `set_physical` to fail if the file is not on disk, and if the `recordDelimiter` argument is not set since the default value for that argument calls `detect_delim`