### PR TITLE
check for missingValueCode and missingValueCodeExplanation

### DIFF
--- a/R/set_attributes.R
+++ b/R/set_attributes.R
@@ -152,7 +152,7 @@ set_attribute <- function(row, factors = NULL) {
   measurementScale <- setNames(list(list()), s)
   measurementScale[[s]] <- node
   missingValueCode <- NULL
-  if (!is.na(row[["missingValueCode"]])) {
+  if (!is.na(row[["missingValueCode"]]) && !is.na(row[["missingValueCodeExplanation"]])) {
     missingValueCode <-
       list(
         code = na2empty(row[["missingValueCode"]]),


### PR DESCRIPTION
Hi @cboettig - When setting attributes, suggest it would be helpful if setting `missingValueCode` would check for the presence of both `missingValueCode` (code) and `missingValueCodeExplanation`. This will accommodate situations where the `missingValueCode` (code) is a unquoted, logical NA.