### PR TITLE
Add documentation regarding dimensionless units

### DIFF
--- a/R/set_attributes.R
+++ b/R/set_attributes.R
@@ -12,45 +12,56 @@
 #' headers shown here.  The attributes data frame must contain columns for required metadata.
 #' These are:
 #'
-#' For all data:
-#' - attributeName (required, free text field)
+#' \strong{For all data:}
 #' 
-#' - attributeDefinition (required, free text field)
+#' \itemize{
+#'   \item attributeName (required, free text field)
 #' 
-#' - measurementScale (required, "nominal", "ordinal", "ratio", "interval", or "dateTime",
+#'   \item attributeDefinition (required, free text field)
+#' 
+#'   \item measurementScale (required, "nominal", "ordinal", "ratio", "interval", or "dateTime",
 #'  case sensitive) but it can be inferred from col_classes.
 #'  
-#' - domain (required, "numericDomain", "textDomain", "enumeratedDomain", or "dateTimeDomain",
+#'   \item domain (required, "numericDomain", "textDomain", "enumeratedDomain", or "dateTimeDomain",
 #'  case sensitive) but it can be inferred from col_classes.
-#'
-#' For numeric (ratio or interval) data:
-#' - unit (required). Unitless values should use "dimensionless" as the unit.
-#'
-#' For character (textDomain) data:
-#' - definition (required)
-#'
-#' For dateTime data:
-#' - formatString (required)
+#' }
+#' 
+#' \strong{For numeric (ratio or interval) data:}
+#' \itemize{
+#'   \item unit (required). Unitless values should use "dimensionless" as the unit.
+#' }
+#' 
+#' \strong{For character (textDomain) data:}
+#' \itemize{
+#'   \item definition (required)
+#' }
+#' 
+#' \strong{For dateTime data:}
+#' \itemize{
+#'   \item formatString (required)
+#' }
 #' 
 #' Other optional allowed columns in the attributes table are:
 #' source, pattern, precision, numberType, missingValueCode, missingValueCodeExplanation,
 #' attributeLabel, storageType, minimum, maximum
 #'
-#' The factors data frame, required for attributes in an enumerated domain, must use only the
+#' The \strong{factors} data frame, required for attributes in an enumerated domain, must use only the
 #'  following recognized column headers:
+#' \itemize{
+#'   \item attributeName (required)
+#'   \item code (required)
+#'   \item definition (required)
+#' }
 #' 
-#' - attributeName (required)
-#' - code (required)
-#' - definition (required)
-#'
-#' The missingValues data frame, optional, can be used in the case that multiple missing value codes
+#' The \strong{missingValues} data frame, optional, can be used in the case that multiple missing value codes
 #' need to be set for the same attribute. This table must contain the following recognized column
 #' headers.
+#' \itemize{
+#'   \item attributeName (required)
+#'   \item code (required)
+#'   \item definition (required)
+#' }
 #' 
-#' - attributeName (required)
-#' - code (required)
-#' - definition (required)
-#'
 #' @return an eml "attributeList" object
 #' @export
 set_attributes <-

--- a/R/set_attributes.R
+++ b/R/set_attributes.R
@@ -141,6 +141,9 @@ set_attribute <- function(row, factors = NULL, missingValues = NULL) {
           "' is not a recognized standard unit; treating as custom unit. ",
           "Please be sure you also define a custom unit in your EML record, ",
           "or replace with a recognized standard unit. ",
+          ifelse(is.na(row[["unit"]]), 
+                 'For unitless values, use "dimensionless" as the unit. ',
+                 NULL),
           "See set_unitList() for details."
       )
     } else {

--- a/R/set_attributes.R
+++ b/R/set_attributes.R
@@ -24,7 +24,7 @@
 #'  case sensitive) but it can be inferred from col_classes.
 #'
 #' For numeric (ratio or interval) data:
-#' - unit (required)
+#' - unit (required). Unitless values should use "dimensionless" as the unit.
 #'
 #' For character (textDomain) data:
 #' - definition (required)

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -70,7 +70,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -99,6 +99,9 @@
       <a href="articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -139,7 +142,7 @@ COPYRIGHT HOLDER: Carl Boettiger
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/LICENSE.html
+++ b/docs/LICENSE.html
@@ -70,7 +70,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -99,6 +99,9 @@
       <a href="articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -143,7 +146,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/articles/creating-EML.html
+++ b/docs/articles/creating-EML.html
@@ -37,7 +37,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -67,6 +67,9 @@
     </li>
   </ul>
 </li>
+<li>
+  <a href="../news/index.html">Changelog</a>
+</li>
       </ul>
 <ul class="nav navbar-nav navbar-right">
 <li>
@@ -90,7 +93,7 @@
       <h1>Creating EML</h1>
                         <h4 class="author">Carl Boettiger</h4>
             
-            <h4 class="date">2019-01-30</h4>
+            <h4 class="date">2019-05-19</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/ropensci/EML/blob/master/vignettes/creating-EML.Rmd"><code>vignettes/creating-EML.Rmd</code></a></small>
       <div class="hidden name"><code>creating-EML.Rmd</code></div>
@@ -101,11 +104,6 @@
     
 <div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb1-1" data-line-number="1"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(EML)</a>
 <a class="sourceLine" id="cb1-2" data-line-number="2"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(emld)</a></code></pre></div>
-<pre><code>## 
-## Attaching package: 'emld'</code></pre>
-<pre><code>## The following object is masked from 'package:EML':
-## 
-##     eml_validate</code></pre>
 <p>Here we construct a common EML file, including:</p>
 <ul>
 <li>Constructing more complete lists of authors, publishers and contact.</li>
@@ -122,26 +120,26 @@
 <a href="#overview-of-the-eml-hierarchy" class="anchor"></a>Overview of the EML hierarchy</h3>
 <p>A basic knowledge of the components of an EML metadata file is essential to being able to take full advantage of the language. While more complete information can be found in the <a href="https://knb.ecoinformatics.org/#external//emlparser/docs/eml-2.1.1/index.html">official schema documentation</a>, here we provide a general overview of commonly used metadata elements most relevant to describing data tables.</p>
 <p>This schematic shows each of the metadata elements we will generate. Most these elements have sub-components (e.g. a ‘publisher’ may have a name, address, and so forth) which are not shown for simplicity. Other optional fields we will not be generating in this example are also not shown.</p>
-<div class="sourceCode" id="cb4"><pre class="sourceCode yaml"><code class="sourceCode yaml"><a class="sourceLine" id="cb4-1" data-line-number="1"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> eml</a>
-<a class="sourceLine" id="cb4-2" data-line-number="2">  <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> dataset</a>
-<a class="sourceLine" id="cb4-3" data-line-number="3">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> creator</a>
-<a class="sourceLine" id="cb4-4" data-line-number="4">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> title</a>
-<a class="sourceLine" id="cb4-5" data-line-number="5">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> publisher</a>
-<a class="sourceLine" id="cb4-6" data-line-number="6">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> pubDate</a>
-<a class="sourceLine" id="cb4-7" data-line-number="7">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> keywords</a>
-<a class="sourceLine" id="cb4-8" data-line-number="8">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> abstract </a>
-<a class="sourceLine" id="cb4-9" data-line-number="9">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> intellectualRights</a>
-<a class="sourceLine" id="cb4-10" data-line-number="10">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> contact</a>
-<a class="sourceLine" id="cb4-11" data-line-number="11">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> methods</a>
-<a class="sourceLine" id="cb4-12" data-line-number="12">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> coverage</a>
-<a class="sourceLine" id="cb4-13" data-line-number="13">      <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> geographicCoverage</a>
-<a class="sourceLine" id="cb4-14" data-line-number="14">      <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> temporalCoverage</a>
-<a class="sourceLine" id="cb4-15" data-line-number="15">      <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> taxonomicCoverage</a>
-<a class="sourceLine" id="cb4-16" data-line-number="16">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> dataTable</a>
-<a class="sourceLine" id="cb4-17" data-line-number="17">      <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> entityName</a>
-<a class="sourceLine" id="cb4-18" data-line-number="18">      <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> entityDescription</a>
-<a class="sourceLine" id="cb4-19" data-line-number="19">      <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> physical</a>
-<a class="sourceLine" id="cb4-20" data-line-number="20">      <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> attributeList</a></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode yaml"><code class="sourceCode yaml"><a class="sourceLine" id="cb2-1" data-line-number="1"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> eml</a>
+<a class="sourceLine" id="cb2-2" data-line-number="2">  <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> dataset</a>
+<a class="sourceLine" id="cb2-3" data-line-number="3">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> creator</a>
+<a class="sourceLine" id="cb2-4" data-line-number="4">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> title</a>
+<a class="sourceLine" id="cb2-5" data-line-number="5">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> publisher</a>
+<a class="sourceLine" id="cb2-6" data-line-number="6">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> pubDate</a>
+<a class="sourceLine" id="cb2-7" data-line-number="7">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> keywords</a>
+<a class="sourceLine" id="cb2-8" data-line-number="8">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> abstract </a>
+<a class="sourceLine" id="cb2-9" data-line-number="9">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> intellectualRights</a>
+<a class="sourceLine" id="cb2-10" data-line-number="10">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> contact</a>
+<a class="sourceLine" id="cb2-11" data-line-number="11">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> methods</a>
+<a class="sourceLine" id="cb2-12" data-line-number="12">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> coverage</a>
+<a class="sourceLine" id="cb2-13" data-line-number="13">      <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> geographicCoverage</a>
+<a class="sourceLine" id="cb2-14" data-line-number="14">      <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> temporalCoverage</a>
+<a class="sourceLine" id="cb2-15" data-line-number="15">      <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> taxonomicCoverage</a>
+<a class="sourceLine" id="cb2-16" data-line-number="16">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> dataTable</a>
+<a class="sourceLine" id="cb2-17" data-line-number="17">      <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> entityName</a>
+<a class="sourceLine" id="cb2-18" data-line-number="18">      <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> entityDescription</a>
+<a class="sourceLine" id="cb2-19" data-line-number="19">      <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> physical</a>
+<a class="sourceLine" id="cb2-20" data-line-number="20">      <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Arithmetic">-</a></span> attributeList</a></code></pre></div>
 </div>
 <div id="our-example-re-creating-hf205-xml" class="section level3">
 <h3 class="hasAnchor">
@@ -158,215 +156,215 @@
 <h2 class="hasAnchor">
 <a href="#attribute-metadata" class="anchor"></a>Attribute Metadata</h2>
 <p>A fundamental part of EML metadata is a description of the attributes (usually columns) of a text file (usually a csv file) containing the data being described. This is the heart of many EML files.</p>
-<div class="sourceCode" id="cb5"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb5-1" data-line-number="1">attributes &lt;-</a>
-<a class="sourceLine" id="cb5-2" data-line-number="2">tibble<span class="op">::</span><span class="kw"><a href="https://tibble.tidyverse.org/reference/tribble.html">tribble</a></span>(</a>
-<a class="sourceLine" id="cb5-3" data-line-number="3"><span class="op">~</span>attributeName, <span class="op">~</span>attributeDefinition,                                                 <span class="op">~</span>formatString, <span class="op">~</span>definition,        <span class="op">~</span>unit,   <span class="op">~</span>numberType,</a>
-<a class="sourceLine" id="cb5-4" data-line-number="4">  <span class="st">"run.num"</span>,    <span class="st">"which run number (=block). Range: 1 - 6. (integer)"</span>,                 <span class="ot">NA</span>,            <span class="st">"which run number"</span>, <span class="ot">NA</span>,       <span class="ot">NA</span>,</a>
-<a class="sourceLine" id="cb5-5" data-line-number="5">  <span class="st">"year"</span>,       <span class="st">"year, 2012"</span>,                                                         <span class="st">"YYYY"</span>,        <span class="ot">NA</span>,                 <span class="ot">NA</span>,       <span class="ot">NA</span>,</a>
-<a class="sourceLine" id="cb5-6" data-line-number="6">  <span class="st">"day"</span>,        <span class="st">"Julian day. Range: 170 - 209."</span>,                                      <span class="st">"DDD"</span>,         <span class="ot">NA</span>,                 <span class="ot">NA</span>,       <span class="ot">NA</span>,</a>
-<a class="sourceLine" id="cb5-7" data-line-number="7">  <span class="st">"hour.min"</span>,   <span class="st">"hour and minute of observation. Range 1 - 2400 (integer)"</span>,           <span class="st">"hhmm"</span>,        <span class="ot">NA</span>,                 <span class="ot">NA</span>,       <span class="ot">NA</span>,</a>
-<a class="sourceLine" id="cb5-8" data-line-number="8">  <span class="st">"i.flag"</span>,     <span class="st">"is variable Real, Interpolated or Bad (character/factor)"</span>,           <span class="ot">NA</span>,            <span class="ot">NA</span>,                 <span class="ot">NA</span>,       <span class="ot">NA</span>,</a>
-<a class="sourceLine" id="cb5-9" data-line-number="9">  <span class="st">"variable"</span>,   <span class="st">"what variable being measured in what treatment (character/factor)."</span>, <span class="ot">NA</span>,            <span class="ot">NA</span>,                 <span class="ot">NA</span>,       <span class="ot">NA</span>,</a>
-<a class="sourceLine" id="cb5-10" data-line-number="10">  <span class="st">"value.i"</span>,    <span class="st">"value of measured variable for run.num on year/day/hour.min."</span>,       <span class="ot">NA</span>,            <span class="ot">NA</span>,                 <span class="ot">NA</span>,       <span class="ot">NA</span>,</a>
-<a class="sourceLine" id="cb5-11" data-line-number="11">  <span class="st">"length"</span>,    <span class="st">"length of the species in meters (dummy example of numeric data)"</span>,     <span class="ot">NA</span>,            <span class="ot">NA</span>,                 <span class="st">"meter"</span>,  <span class="st">"real"</span>)</a></code></pre></div>
+<div class="sourceCode" id="cb3"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb3-1" data-line-number="1">attributes &lt;-</a>
+<a class="sourceLine" id="cb3-2" data-line-number="2">tibble<span class="op">::</span><span class="kw"><a href="https://tibble.tidyverse.org/reference/tribble.html">tribble</a></span>(</a>
+<a class="sourceLine" id="cb3-3" data-line-number="3"><span class="op">~</span>attributeName, <span class="op">~</span>attributeDefinition,                                                 <span class="op">~</span>formatString, <span class="op">~</span>definition,        <span class="op">~</span>unit,   <span class="op">~</span>numberType,</a>
+<a class="sourceLine" id="cb3-4" data-line-number="4">  <span class="st">"run.num"</span>,    <span class="st">"which run number (=block). Range: 1 - 6. (integer)"</span>,                 <span class="ot">NA</span>,            <span class="st">"which run number"</span>, <span class="ot">NA</span>,       <span class="ot">NA</span>,</a>
+<a class="sourceLine" id="cb3-5" data-line-number="5">  <span class="st">"year"</span>,       <span class="st">"year, 2012"</span>,                                                         <span class="st">"YYYY"</span>,        <span class="ot">NA</span>,                 <span class="ot">NA</span>,       <span class="ot">NA</span>,</a>
+<a class="sourceLine" id="cb3-6" data-line-number="6">  <span class="st">"day"</span>,        <span class="st">"Julian day. Range: 170 - 209."</span>,                                      <span class="st">"DDD"</span>,         <span class="ot">NA</span>,                 <span class="ot">NA</span>,       <span class="ot">NA</span>,</a>
+<a class="sourceLine" id="cb3-7" data-line-number="7">  <span class="st">"hour.min"</span>,   <span class="st">"hour and minute of observation. Range 1 - 2400 (integer)"</span>,           <span class="st">"hhmm"</span>,        <span class="ot">NA</span>,                 <span class="ot">NA</span>,       <span class="ot">NA</span>,</a>
+<a class="sourceLine" id="cb3-8" data-line-number="8">  <span class="st">"i.flag"</span>,     <span class="st">"is variable Real, Interpolated or Bad (character/factor)"</span>,           <span class="ot">NA</span>,            <span class="ot">NA</span>,                 <span class="ot">NA</span>,       <span class="ot">NA</span>,</a>
+<a class="sourceLine" id="cb3-9" data-line-number="9">  <span class="st">"variable"</span>,   <span class="st">"what variable being measured in what treatment (character/factor)."</span>, <span class="ot">NA</span>,            <span class="ot">NA</span>,                 <span class="ot">NA</span>,       <span class="ot">NA</span>,</a>
+<a class="sourceLine" id="cb3-10" data-line-number="10">  <span class="st">"value.i"</span>,    <span class="st">"value of measured variable for run.num on year/day/hour.min."</span>,       <span class="ot">NA</span>,            <span class="ot">NA</span>,                 <span class="ot">NA</span>,       <span class="ot">NA</span>,</a>
+<a class="sourceLine" id="cb3-11" data-line-number="11">  <span class="st">"length"</span>,    <span class="st">"length of the species in meters (dummy example of numeric data)"</span>,     <span class="ot">NA</span>,            <span class="ot">NA</span>,                 <span class="st">"meter"</span>,  <span class="st">"real"</span>)</a></code></pre></div>
 <p>Every column (attribute) in the dataset needs an <code>attributeName</code> (column name, as it appears in the CSV file) and <code>attributeDefinition</code>, a longer description of what the column contains. Additional information required depends on the data type:</p>
 <p><strong>Strings</strong> (character vectors) data just needs a “definition” value, often the same as the <code>attributeDefinition</code> in this case.</p>
 <p><strong>Numeric</strong> data needs a <code>numberType</code> (e.g. “real”, “integer”), and a unit.</p>
 <p><strong>Dates</strong> need a date format.</p>
 <p><strong>Factors</strong> (enumerated domains) need to specify definitions for each of the code terms appearing in the data columns. This does not fit so nicely in the above table, where each attribute is a single row, so if data uses factors (instead of non-enumerated strings), these definitions must be provided in a separate table. The format expected of this table has three columns: <code>attributeName</code> (as before), <code>code</code>, and <code>definition</code>. Note that <code>attributeName</code> is simply repeated for all codes belonging to a common attribute.</p>
 <p>In this case we have three attributes that are factors, To make the code below more readable (aligning code and definitions side by side), we define these first as named character vectors, and convert that to a <code>data.frame</code>. (The <code><a href="https://dplyr.tidyverse.org/reference/reexports.html">dplyr::frame_data</a></code> function also permits this more readable way to define data.frames inline).</p>
-<div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb6-1" data-line-number="1">i.flag &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="dt">R =</span> <span class="st">"real"</span>,</a>
-<a class="sourceLine" id="cb6-2" data-line-number="2">            <span class="dt">I =</span> <span class="st">"interpolated"</span>,</a>
-<a class="sourceLine" id="cb6-3" data-line-number="3">            <span class="dt">B =</span> <span class="st">"bad"</span>)</a>
-<a class="sourceLine" id="cb6-4" data-line-number="4">variable &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(</a>
-<a class="sourceLine" id="cb6-5" data-line-number="5">  <span class="dt">control  =</span> <span class="st">"no prey added"</span>,</a>
-<a class="sourceLine" id="cb6-6" data-line-number="6">  <span class="dt">low      =</span> <span class="st">"0.125 mg prey added ml-1 d-1"</span>,</a>
-<a class="sourceLine" id="cb6-7" data-line-number="7">  <span class="dt">med.low  =</span> <span class="st">"0,25 mg prey added ml-1 d-1"</span>,</a>
-<a class="sourceLine" id="cb6-8" data-line-number="8">  <span class="dt">med.high =</span> <span class="st">"0.5 mg prey added ml-1 d-1"</span>,</a>
-<a class="sourceLine" id="cb6-9" data-line-number="9">  <span class="dt">high     =</span> <span class="st">"1.0 mg prey added ml-1 d-1"</span>,</a>
-<a class="sourceLine" id="cb6-10" data-line-number="10">  <span class="dt">air.temp =</span> <span class="st">"air temperature measured just above all plants (1 thermocouple)"</span>,</a>
-<a class="sourceLine" id="cb6-11" data-line-number="11">  <span class="dt">water.temp =</span> <span class="st">"water temperature measured within each pitcher"</span>,</a>
-<a class="sourceLine" id="cb6-12" data-line-number="12">  <span class="dt">par       =</span> <span class="st">"photosynthetic active radiation (PAR) measured just above all plants (1 sensor)"</span></a>
-<a class="sourceLine" id="cb6-13" data-line-number="13">)</a>
-<a class="sourceLine" id="cb6-14" data-line-number="14"></a>
-<a class="sourceLine" id="cb6-15" data-line-number="15">value.i &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(</a>
-<a class="sourceLine" id="cb6-16" data-line-number="16">  <span class="dt">control  =</span> <span class="st">"% dissolved oxygen"</span>,</a>
-<a class="sourceLine" id="cb6-17" data-line-number="17">  <span class="dt">low      =</span> <span class="st">"% dissolved oxygen"</span>,</a>
-<a class="sourceLine" id="cb6-18" data-line-number="18">  <span class="dt">med.low  =</span> <span class="st">"% dissolved oxygen"</span>,</a>
-<a class="sourceLine" id="cb6-19" data-line-number="19">  <span class="dt">med.high =</span> <span class="st">"% dissolved oxygen"</span>,</a>
-<a class="sourceLine" id="cb6-20" data-line-number="20">  <span class="dt">high     =</span> <span class="st">"% dissolved oxygen"</span>,</a>
-<a class="sourceLine" id="cb6-21" data-line-number="21">  <span class="dt">air.temp =</span> <span class="st">"degrees C"</span>,</a>
-<a class="sourceLine" id="cb6-22" data-line-number="22">  <span class="dt">water.temp =</span> <span class="st">"degrees C"</span>,</a>
-<a class="sourceLine" id="cb6-23" data-line-number="23">  <span class="dt">par      =</span> <span class="st">"micromoles m-1 s-1"</span></a>
-<a class="sourceLine" id="cb6-24" data-line-number="24">)</a>
-<a class="sourceLine" id="cb6-25" data-line-number="25"></a>
-<a class="sourceLine" id="cb6-26" data-line-number="26"><span class="co">## Write these into the data.frame format</span></a>
-<a class="sourceLine" id="cb6-27" data-line-number="27">factors &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/cbind">rbind</a></span>(</a>
-<a class="sourceLine" id="cb6-28" data-line-number="28"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/data.frame">data.frame</a></span>(</a>
-<a class="sourceLine" id="cb6-29" data-line-number="29">  <span class="dt">attributeName =</span> <span class="st">"i.flag"</span>,</a>
-<a class="sourceLine" id="cb6-30" data-line-number="30">  <span class="dt">code =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/names">names</a></span>(i.flag),</a>
-<a class="sourceLine" id="cb6-31" data-line-number="31">  <span class="dt">definition =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/unname">unname</a></span>(i.flag)</a>
-<a class="sourceLine" id="cb6-32" data-line-number="32">),</a>
-<a class="sourceLine" id="cb6-33" data-line-number="33"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/data.frame">data.frame</a></span>(</a>
-<a class="sourceLine" id="cb6-34" data-line-number="34">  <span class="dt">attributeName =</span> <span class="st">"variable"</span>,</a>
-<a class="sourceLine" id="cb6-35" data-line-number="35">  <span class="dt">code =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/names">names</a></span>(variable),</a>
-<a class="sourceLine" id="cb6-36" data-line-number="36">  <span class="dt">definition =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/unname">unname</a></span>(variable)</a>
-<a class="sourceLine" id="cb6-37" data-line-number="37">),</a>
-<a class="sourceLine" id="cb6-38" data-line-number="38"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/data.frame">data.frame</a></span>(</a>
-<a class="sourceLine" id="cb6-39" data-line-number="39">  <span class="dt">attributeName =</span> <span class="st">"value.i"</span>,</a>
-<a class="sourceLine" id="cb6-40" data-line-number="40">  <span class="dt">code =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/names">names</a></span>(value.i),</a>
-<a class="sourceLine" id="cb6-41" data-line-number="41">  <span class="dt">definition =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/unname">unname</a></span>(value.i)</a>
-<a class="sourceLine" id="cb6-42" data-line-number="42">)</a>
-<a class="sourceLine" id="cb6-43" data-line-number="43">)</a></code></pre></div>
+<div class="sourceCode" id="cb4"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb4-1" data-line-number="1">i.flag &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="dt">R =</span> <span class="st">"real"</span>,</a>
+<a class="sourceLine" id="cb4-2" data-line-number="2">            <span class="dt">I =</span> <span class="st">"interpolated"</span>,</a>
+<a class="sourceLine" id="cb4-3" data-line-number="3">            <span class="dt">B =</span> <span class="st">"bad"</span>)</a>
+<a class="sourceLine" id="cb4-4" data-line-number="4">variable &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(</a>
+<a class="sourceLine" id="cb4-5" data-line-number="5">  <span class="dt">control  =</span> <span class="st">"no prey added"</span>,</a>
+<a class="sourceLine" id="cb4-6" data-line-number="6">  <span class="dt">low      =</span> <span class="st">"0.125 mg prey added ml-1 d-1"</span>,</a>
+<a class="sourceLine" id="cb4-7" data-line-number="7">  <span class="dt">med.low  =</span> <span class="st">"0,25 mg prey added ml-1 d-1"</span>,</a>
+<a class="sourceLine" id="cb4-8" data-line-number="8">  <span class="dt">med.high =</span> <span class="st">"0.5 mg prey added ml-1 d-1"</span>,</a>
+<a class="sourceLine" id="cb4-9" data-line-number="9">  <span class="dt">high     =</span> <span class="st">"1.0 mg prey added ml-1 d-1"</span>,</a>
+<a class="sourceLine" id="cb4-10" data-line-number="10">  <span class="dt">air.temp =</span> <span class="st">"air temperature measured just above all plants (1 thermocouple)"</span>,</a>
+<a class="sourceLine" id="cb4-11" data-line-number="11">  <span class="dt">water.temp =</span> <span class="st">"water temperature measured within each pitcher"</span>,</a>
+<a class="sourceLine" id="cb4-12" data-line-number="12">  <span class="dt">par       =</span> <span class="st">"photosynthetic active radiation (PAR) measured just above all plants (1 sensor)"</span></a>
+<a class="sourceLine" id="cb4-13" data-line-number="13">)</a>
+<a class="sourceLine" id="cb4-14" data-line-number="14"></a>
+<a class="sourceLine" id="cb4-15" data-line-number="15">value.i &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(</a>
+<a class="sourceLine" id="cb4-16" data-line-number="16">  <span class="dt">control  =</span> <span class="st">"% dissolved oxygen"</span>,</a>
+<a class="sourceLine" id="cb4-17" data-line-number="17">  <span class="dt">low      =</span> <span class="st">"% dissolved oxygen"</span>,</a>
+<a class="sourceLine" id="cb4-18" data-line-number="18">  <span class="dt">med.low  =</span> <span class="st">"% dissolved oxygen"</span>,</a>
+<a class="sourceLine" id="cb4-19" data-line-number="19">  <span class="dt">med.high =</span> <span class="st">"% dissolved oxygen"</span>,</a>
+<a class="sourceLine" id="cb4-20" data-line-number="20">  <span class="dt">high     =</span> <span class="st">"% dissolved oxygen"</span>,</a>
+<a class="sourceLine" id="cb4-21" data-line-number="21">  <span class="dt">air.temp =</span> <span class="st">"degrees C"</span>,</a>
+<a class="sourceLine" id="cb4-22" data-line-number="22">  <span class="dt">water.temp =</span> <span class="st">"degrees C"</span>,</a>
+<a class="sourceLine" id="cb4-23" data-line-number="23">  <span class="dt">par      =</span> <span class="st">"micromoles m-1 s-1"</span></a>
+<a class="sourceLine" id="cb4-24" data-line-number="24">)</a>
+<a class="sourceLine" id="cb4-25" data-line-number="25"></a>
+<a class="sourceLine" id="cb4-26" data-line-number="26"><span class="co">## Write these into the data.frame format</span></a>
+<a class="sourceLine" id="cb4-27" data-line-number="27">factors &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/cbind">rbind</a></span>(</a>
+<a class="sourceLine" id="cb4-28" data-line-number="28"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/data.frame">data.frame</a></span>(</a>
+<a class="sourceLine" id="cb4-29" data-line-number="29">  <span class="dt">attributeName =</span> <span class="st">"i.flag"</span>,</a>
+<a class="sourceLine" id="cb4-30" data-line-number="30">  <span class="dt">code =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/names">names</a></span>(i.flag),</a>
+<a class="sourceLine" id="cb4-31" data-line-number="31">  <span class="dt">definition =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/unname">unname</a></span>(i.flag)</a>
+<a class="sourceLine" id="cb4-32" data-line-number="32">),</a>
+<a class="sourceLine" id="cb4-33" data-line-number="33"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/data.frame">data.frame</a></span>(</a>
+<a class="sourceLine" id="cb4-34" data-line-number="34">  <span class="dt">attributeName =</span> <span class="st">"variable"</span>,</a>
+<a class="sourceLine" id="cb4-35" data-line-number="35">  <span class="dt">code =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/names">names</a></span>(variable),</a>
+<a class="sourceLine" id="cb4-36" data-line-number="36">  <span class="dt">definition =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/unname">unname</a></span>(variable)</a>
+<a class="sourceLine" id="cb4-37" data-line-number="37">),</a>
+<a class="sourceLine" id="cb4-38" data-line-number="38"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/data.frame">data.frame</a></span>(</a>
+<a class="sourceLine" id="cb4-39" data-line-number="39">  <span class="dt">attributeName =</span> <span class="st">"value.i"</span>,</a>
+<a class="sourceLine" id="cb4-40" data-line-number="40">  <span class="dt">code =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/names">names</a></span>(value.i),</a>
+<a class="sourceLine" id="cb4-41" data-line-number="41">  <span class="dt">definition =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/unname">unname</a></span>(value.i)</a>
+<a class="sourceLine" id="cb4-42" data-line-number="42">)</a>
+<a class="sourceLine" id="cb4-43" data-line-number="43">)</a></code></pre></div>
 <p>With these two data frames in place, we are ready to create our <code>attributeList</code> element:</p>
-<div class="sourceCode" id="cb7"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb7-1" data-line-number="1">attributeList &lt;-<span class="st"> </span><span class="kw"><a href="../reference/set_attributes.html">set_attributes</a></span>(attributes, factors, <span class="dt">col_classes =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="st">"character"</span>, <span class="st">"Date"</span>, <span class="st">"Date"</span>, <span class="st">"Date"</span>, <span class="st">"factor"</span>, <span class="st">"factor"</span>, <span class="st">"factor"</span>, <span class="st">"numeric"</span>))</a></code></pre></div>
+<div class="sourceCode" id="cb5"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb5-1" data-line-number="1">attributeList &lt;-<span class="st"> </span><span class="kw"><a href="../reference/set_attributes.html">set_attributes</a></span>(attributes, factors, <span class="dt">col_classes =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="st">"character"</span>, <span class="st">"Date"</span>, <span class="st">"Date"</span>, <span class="st">"Date"</span>, <span class="st">"factor"</span>, <span class="st">"factor"</span>, <span class="st">"factor"</span>, <span class="st">"numeric"</span>))</a></code></pre></div>
 </div>
 <div id="data-file-format" class="section level2">
 <h2 class="hasAnchor">
 <a href="#data-file-format" class="anchor"></a>Data file format</h2>
 <p>The documentation of a <code>dataTable</code> also requires a description of the file format itself. From where can the data file be downloaded? Is it in CSV format, or TSV (tab-separated), or some other format? Are there header lines that should be skipped? This information documents the physical file itself, and is provided using the <code>physical</code> child element to the <code>dataTable</code>. To assist in documenting common file types such as CSV files, the <code>EML</code> R package provides the function <code>set_physical</code>, which takes as arguments many of these common options. By default these options are already set to document a standard <code>csv</code> formatted object, so we do not need to specify delimiters and so forth if our file conforms to that. We simply provide the name of the file, which is used as the <code>objectName</code>. (See examples for <code><a href="../reference/set_physical.html">set_physical()</a></code> for reading other common variations, analogous to the options covered in R’s <code><a href="https://www.rdocumentation.org/packages/utils/topics/read.table">read.table()</a></code> function.)</p>
-<div class="sourceCode" id="cb8"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb8-1" data-line-number="1">physical &lt;-<span class="st"> </span><span class="kw"><a href="../reference/set_physical.html">set_physical</a></span>(<span class="st">"hf205-01-TPexp1.csv"</span>)</a></code></pre></div>
+<div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb6-1" data-line-number="1">physical &lt;-<span class="st"> </span><span class="kw"><a href="../reference/set_physical.html">set_physical</a></span>(<span class="st">"hf205-01-TPexp1.csv"</span>)</a></code></pre></div>
 </div>
 <div id="assembling-the-datatable" class="section level2">
 <h2 class="hasAnchor">
 <a href="#assembling-the-datatable" class="anchor"></a>Assembling the <code>dataTable</code>
 </h2>
 <p>Once we have defined the <code>attributeList</code> and <code>physical</code> file, we can now assemble the <code>dataTable</code> element itself. Unlike the old <code>EML</code> R package, in <code>EML</code> version 2.0 there is no need to call <code>new()</code> to create elements. Everything is just a list. Template lists for a given class can be viewed with the <code><a href="https://www.rdocumentation.org/packages/emld/topics/template">emld::template()</a></code> function.</p>
-<div class="sourceCode" id="cb9"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb9-1" data-line-number="1">dataTable &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(</a>
-<a class="sourceLine" id="cb9-2" data-line-number="2">                 <span class="dt">entityName =</span> <span class="st">"hf205-01-TPexp1.csv"</span>,</a>
-<a class="sourceLine" id="cb9-3" data-line-number="3">                 <span class="dt">entityDescription =</span> <span class="st">"tipping point experiment 1"</span>,</a>
-<a class="sourceLine" id="cb9-4" data-line-number="4">                 <span class="dt">physical =</span> physical,</a>
-<a class="sourceLine" id="cb9-5" data-line-number="5">                 <span class="dt">attributeList =</span> attributeList)</a></code></pre></div>
+<div class="sourceCode" id="cb7"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb7-1" data-line-number="1">dataTable &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(</a>
+<a class="sourceLine" id="cb7-2" data-line-number="2">                 <span class="dt">entityName =</span> <span class="st">"hf205-01-TPexp1.csv"</span>,</a>
+<a class="sourceLine" id="cb7-3" data-line-number="3">                 <span class="dt">entityDescription =</span> <span class="st">"tipping point experiment 1"</span>,</a>
+<a class="sourceLine" id="cb7-4" data-line-number="4">                 <span class="dt">physical =</span> physical,</a>
+<a class="sourceLine" id="cb7-5" data-line-number="5">                 <span class="dt">attributeList =</span> attributeList)</a></code></pre></div>
 </div>
 <div id="coverage-metadata" class="section level2">
 <h2 class="hasAnchor">
 <a href="#coverage-metadata" class="anchor"></a>Coverage metadata</h2>
 <p>One of the most common and useful types of metadata is coverage information, specifying the temporal, taxonomic, and geographic coverage of the data. This kind of metadata is frequently indexed by data repositories, allowing users to search for all data about a specific region, time, or species. In EML, these descriptions can take many forms, allowing for detailed descriptions as well as more general terms when such precision is not possible (such as geological epoch instead of date range, or higher taxonomic rank information in place of species definitions.)</p>
 <p>Most common specifications can be made using the more convenient but less flexible <code><a href="../reference/set_coverage.html">set_coverage()</a></code> function in EML. This function takes a date range or list of specific dates, a list of scientific names, a geographic description and bounding boxes, as shown here:</p>
-<div class="sourceCode" id="cb10"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb10-1" data-line-number="1">geographicDescription &lt;-<span class="st"> "Harvard Forest Greenhouse, Tom Swamp Tract (Harvard Forest)"</span></a>
-<a class="sourceLine" id="cb10-2" data-line-number="2"></a>
-<a class="sourceLine" id="cb10-3" data-line-number="3"></a>
-<a class="sourceLine" id="cb10-4" data-line-number="4">coverage &lt;-<span class="st"> </span></a>
-<a class="sourceLine" id="cb10-5" data-line-number="5"><span class="st">  </span><span class="kw"><a href="../reference/set_coverage.html">set_coverage</a></span>(<span class="dt">begin =</span> <span class="st">'2012-06-01'</span>, <span class="dt">end =</span> <span class="st">'2013-12-31'</span>,</a>
-<a class="sourceLine" id="cb10-6" data-line-number="6">               <span class="dt">sci_names =</span> <span class="st">"Sarracenia purpurea"</span>,</a>
-<a class="sourceLine" id="cb10-7" data-line-number="7">               <span class="dt">geographicDescription =</span> geographicDescription,</a>
-<a class="sourceLine" id="cb10-8" data-line-number="8">               <span class="dt">west =</span> <span class="fl">-122.44</span>, <span class="dt">east =</span> <span class="fl">-117.15</span>, </a>
-<a class="sourceLine" id="cb10-9" data-line-number="9">               <span class="dt">north =</span> <span class="fl">37.38</span>, <span class="dt">south =</span> <span class="fl">30.00</span>,</a>
-<a class="sourceLine" id="cb10-10" data-line-number="10">               <span class="dt">altitudeMin =</span> <span class="dv">160</span>, <span class="dt">altitudeMaximum =</span> <span class="dv">330</span>,</a>
-<a class="sourceLine" id="cb10-11" data-line-number="11">               <span class="dt">altitudeUnits =</span> <span class="st">"meter"</span>)</a></code></pre></div>
+<div class="sourceCode" id="cb8"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb8-1" data-line-number="1">geographicDescription &lt;-<span class="st"> "Harvard Forest Greenhouse, Tom Swamp Tract (Harvard Forest)"</span></a>
+<a class="sourceLine" id="cb8-2" data-line-number="2"></a>
+<a class="sourceLine" id="cb8-3" data-line-number="3"></a>
+<a class="sourceLine" id="cb8-4" data-line-number="4">coverage &lt;-<span class="st"> </span></a>
+<a class="sourceLine" id="cb8-5" data-line-number="5"><span class="st">  </span><span class="kw"><a href="../reference/set_coverage.html">set_coverage</a></span>(<span class="dt">begin =</span> <span class="st">'2012-06-01'</span>, <span class="dt">end =</span> <span class="st">'2013-12-31'</span>,</a>
+<a class="sourceLine" id="cb8-6" data-line-number="6">               <span class="dt">sci_names =</span> <span class="st">"Sarracenia purpurea"</span>,</a>
+<a class="sourceLine" id="cb8-7" data-line-number="7">               <span class="dt">geographicDescription =</span> geographicDescription,</a>
+<a class="sourceLine" id="cb8-8" data-line-number="8">               <span class="dt">west =</span> <span class="fl">-122.44</span>, <span class="dt">east =</span> <span class="fl">-117.15</span>, </a>
+<a class="sourceLine" id="cb8-9" data-line-number="9">               <span class="dt">north =</span> <span class="fl">37.38</span>, <span class="dt">south =</span> <span class="fl">30.00</span>,</a>
+<a class="sourceLine" id="cb8-10" data-line-number="10">               <span class="dt">altitudeMin =</span> <span class="dv">160</span>, <span class="dt">altitudeMaximum =</span> <span class="dv">330</span>,</a>
+<a class="sourceLine" id="cb8-11" data-line-number="11">               <span class="dt">altitudeUnits =</span> <span class="st">"meter"</span>)</a></code></pre></div>
 </div>
 <div id="creating-methods" class="section level2">
 <h2 class="hasAnchor">
 <a href="#creating-methods" class="anchor"></a>Creating methods</h2>
 <p>Careful documentation of the methods involved in the experimental design, measurement and collection of data are a key part of metadata. Though frequently documented in scientific papers, such method sections may be too brief or incomplete, and may become more readily disconnected from the data file itself. Such documentation is usually written using word-processing software such as MS Word, LaTeX or markdown. Users with <code>pandoc</code> installed (which ships as part of RStudio) can install the <code>rmarkdown</code> package to take advantage of its automatic conversion into the DocBook XML format used by EML. Here we open a MS Word file with the methods and read this into our methods element using the helper function <code><a href="../reference/set_methods.html">set_methods()</a></code>. While not used in this example, note that the <code><a href="../reference/set_methods.html">set_methods()</a></code> function also includes many optional arguments for documenting additional information about sampling, or relevant citations.</p>
-<div class="sourceCode" id="cb11"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb11-1" data-line-number="1">methods_file &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/system.file">system.file</a></span>(<span class="st">"examples/hf205-methods.docx"</span>, <span class="dt">package =</span> <span class="st">"EML"</span>)</a>
-<a class="sourceLine" id="cb11-2" data-line-number="2">methods &lt;-<span class="st"> </span><span class="kw"><a href="../reference/set_methods.html">set_methods</a></span>(methods_file)</a></code></pre></div>
+<div class="sourceCode" id="cb9"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb9-1" data-line-number="1">methods_file &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/system.file">system.file</a></span>(<span class="st">"examples/hf205-methods.docx"</span>, <span class="dt">package =</span> <span class="st">"EML"</span>)</a>
+<a class="sourceLine" id="cb9-2" data-line-number="2">methods &lt;-<span class="st"> </span><span class="kw"><a href="../reference/set_methods.html">set_methods</a></span>(methods_file)</a></code></pre></div>
 </div>
 <div id="creating-parties" class="section level2">
 <h2 class="hasAnchor">
 <a href="#creating-parties" class="anchor"></a>Creating parties</h2>
 <p>Individuals and organizations appear in many capacities in an EML document. Meanwhile, R already has a native object class, <code>person</code> for describing individuals, which it uses in citations and package descriptions, among other things. We can use native R function <code><a href="https://www.rdocumentation.org/packages/utils/topics/person">person()</a></code> to create an R <code>person</code> object. Often it is more convenient to use R’s coercion function, <code><a href="https://www.rdocumentation.org/packages/utils/topics/person">as.person()</a></code>, to turn a string with standardized notation into a <code>person</code> class (Though this is not always reliable, for instance, in surnames containing whitespace). However it is constructed, a <code>person</code> class can then be coerced into the appropriate EML object like so:</p>
-<div class="sourceCode" id="cb12"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb12-1" data-line-number="1">R_person &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/utils/topics/person">person</a></span>(<span class="st">"Aaron"</span>, <span class="st">"Ellison"</span>, ,<span class="st">"fakeaddress@email.com"</span>, <span class="st">"cre"</span>, </a>
-<a class="sourceLine" id="cb12-2" data-line-number="2">                  <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="dt">ORCID =</span> <span class="st">"0000-0003-4151-6081"</span>))</a>
-<a class="sourceLine" id="cb12-3" data-line-number="3">aaron &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/emld/topics/as_emld">as_emld</a></span>(R_person)</a></code></pre></div>
+<div class="sourceCode" id="cb10"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb10-1" data-line-number="1">R_person &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/utils/topics/person">person</a></span>(<span class="st">"Aaron"</span>, <span class="st">"Ellison"</span>, ,<span class="st">"fakeaddress@email.com"</span>, <span class="st">"cre"</span>, </a>
+<a class="sourceLine" id="cb10-2" data-line-number="2">                  <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="dt">ORCID =</span> <span class="st">"0000-0003-4151-6081"</span>))</a>
+<a class="sourceLine" id="cb10-3" data-line-number="3">aaron &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/emld/topics/as_emld">as_emld</a></span>(R_person)</a></code></pre></div>
 <p>Likewise this method can be applied to a list of <code>person</code> objects:</p>
-<div class="sourceCode" id="cb13"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb13-1" data-line-number="1">others &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="kw"><a href="https://www.rdocumentation.org/packages/utils/topics/person">as.person</a></span>(<span class="st">"Benjamin Baiser"</span>), <span class="kw"><a href="https://www.rdocumentation.org/packages/utils/topics/person">as.person</a></span>(<span class="st">"Jennifer Sirota"</span>))</a>
-<a class="sourceLine" id="cb13-2" data-line-number="2">associatedParty &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/emld/topics/as_emld">as_emld</a></span>(others)</a>
-<a class="sourceLine" id="cb13-3" data-line-number="3">associatedParty[[<span class="dv">1</span>]]<span class="op">$</span>role &lt;-<span class="st"> "Researcher"</span></a>
-<a class="sourceLine" id="cb13-4" data-line-number="4">associatedParty[[<span class="dv">2</span>]]<span class="op">$</span>role &lt;-<span class="st"> "Researcher"</span></a></code></pre></div>
+<div class="sourceCode" id="cb11"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb11-1" data-line-number="1">others &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="kw"><a href="https://www.rdocumentation.org/packages/utils/topics/person">as.person</a></span>(<span class="st">"Benjamin Baiser"</span>), <span class="kw"><a href="https://www.rdocumentation.org/packages/utils/topics/person">as.person</a></span>(<span class="st">"Jennifer Sirota"</span>))</a>
+<a class="sourceLine" id="cb11-2" data-line-number="2">associatedParty &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/emld/topics/as_emld">as_emld</a></span>(others)</a>
+<a class="sourceLine" id="cb11-3" data-line-number="3">associatedParty[[<span class="dv">1</span>]]<span class="op">$</span>role &lt;-<span class="st"> "Researcher"</span></a>
+<a class="sourceLine" id="cb11-4" data-line-number="4">associatedParty[[<span class="dv">2</span>]]<span class="op">$</span>role &lt;-<span class="st"> "Researcher"</span></a></code></pre></div>
 <p>Note that R only permits certain codes such as <code>ctb</code> be be given in square brackets or as the <code>role</code> slot in a <code>person</code> object.</p>
 <p>We can instead always use the list approach to create any of these elements, instead of the shorthand coercion methods shown above. This permits a bit more flexibility, particularly for constructing elements where we want to include more metadata than R’s <code>person</code> object knows about. Here we define an <code>address</code> element first, since we can then re-use that element in defining both the contact person and publisher of the dataset:</p>
-<div class="sourceCode" id="cb14"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb14-1" data-line-number="1">HF_address &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(</a>
-<a class="sourceLine" id="cb14-2" data-line-number="2">                  <span class="dt">deliveryPoint =</span> <span class="st">"324 North Main Street"</span>,</a>
-<a class="sourceLine" id="cb14-3" data-line-number="3">                  <span class="dt">city =</span> <span class="st">"Petersham"</span>,</a>
-<a class="sourceLine" id="cb14-4" data-line-number="4">                  <span class="dt">administrativeArea =</span> <span class="st">"MA"</span>,</a>
-<a class="sourceLine" id="cb14-5" data-line-number="5">                  <span class="dt">postalCode =</span> <span class="st">"01366"</span>,</a>
-<a class="sourceLine" id="cb14-6" data-line-number="6">                  <span class="dt">country =</span> <span class="st">"USA"</span>)</a></code></pre></div>
-<div class="sourceCode" id="cb15"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb15-1" data-line-number="1">publisher &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(</a>
-<a class="sourceLine" id="cb15-2" data-line-number="2">                 <span class="dt">organizationName =</span> <span class="st">"Harvard Forest"</span>,</a>
-<a class="sourceLine" id="cb15-3" data-line-number="3">                 <span class="dt">address =</span> HF_address)</a></code></pre></div>
-<div class="sourceCode" id="cb16"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb16-1" data-line-number="1">contact &lt;-<span class="st"> </span></a>
-<a class="sourceLine" id="cb16-2" data-line-number="2"><span class="st">  </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(</a>
-<a class="sourceLine" id="cb16-3" data-line-number="3">    <span class="dt">individualName =</span> aaron<span class="op">$</span>individualName,</a>
-<a class="sourceLine" id="cb16-4" data-line-number="4">    <span class="dt">electronicMailAddress =</span> aaron<span class="op">$</span>electronicMailAddress,</a>
-<a class="sourceLine" id="cb16-5" data-line-number="5">    <span class="dt">address =</span> HF_address,</a>
-<a class="sourceLine" id="cb16-6" data-line-number="6">    <span class="dt">organizationName =</span> <span class="st">"Harvard Forest"</span>,</a>
-<a class="sourceLine" id="cb16-7" data-line-number="7">    <span class="dt">phone =</span> <span class="st">"000-000-0000"</span>)</a></code></pre></div>
+<div class="sourceCode" id="cb12"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb12-1" data-line-number="1">HF_address &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(</a>
+<a class="sourceLine" id="cb12-2" data-line-number="2">                  <span class="dt">deliveryPoint =</span> <span class="st">"324 North Main Street"</span>,</a>
+<a class="sourceLine" id="cb12-3" data-line-number="3">                  <span class="dt">city =</span> <span class="st">"Petersham"</span>,</a>
+<a class="sourceLine" id="cb12-4" data-line-number="4">                  <span class="dt">administrativeArea =</span> <span class="st">"MA"</span>,</a>
+<a class="sourceLine" id="cb12-5" data-line-number="5">                  <span class="dt">postalCode =</span> <span class="st">"01366"</span>,</a>
+<a class="sourceLine" id="cb12-6" data-line-number="6">                  <span class="dt">country =</span> <span class="st">"USA"</span>)</a></code></pre></div>
+<div class="sourceCode" id="cb13"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb13-1" data-line-number="1">publisher &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(</a>
+<a class="sourceLine" id="cb13-2" data-line-number="2">                 <span class="dt">organizationName =</span> <span class="st">"Harvard Forest"</span>,</a>
+<a class="sourceLine" id="cb13-3" data-line-number="3">                 <span class="dt">address =</span> HF_address)</a></code></pre></div>
+<div class="sourceCode" id="cb14"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb14-1" data-line-number="1">contact &lt;-<span class="st"> </span></a>
+<a class="sourceLine" id="cb14-2" data-line-number="2"><span class="st">  </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(</a>
+<a class="sourceLine" id="cb14-3" data-line-number="3">    <span class="dt">individualName =</span> aaron<span class="op">$</span>individualName,</a>
+<a class="sourceLine" id="cb14-4" data-line-number="4">    <span class="dt">electronicMailAddress =</span> aaron<span class="op">$</span>electronicMailAddress,</a>
+<a class="sourceLine" id="cb14-5" data-line-number="5">    <span class="dt">address =</span> HF_address,</a>
+<a class="sourceLine" id="cb14-6" data-line-number="6">    <span class="dt">organizationName =</span> <span class="st">"Harvard Forest"</span>,</a>
+<a class="sourceLine" id="cb14-7" data-line-number="7">    <span class="dt">phone =</span> <span class="st">"000-000-0000"</span>)</a></code></pre></div>
 </div>
 <div id="creating-a-keywordset" class="section level2">
 <h2 class="hasAnchor">
 <a href="#creating-a-keywordset" class="anchor"></a>Creating a <code>keywordSet</code>
 </h2>
 <p>Constructing the <code>keywordSet</code> is just a list of lists. Note that everything is a list.</p>
-<div class="sourceCode" id="cb17"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb17-1" data-line-number="1">keywordSet &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(</a>
-<a class="sourceLine" id="cb17-2" data-line-number="2">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(</a>
-<a class="sourceLine" id="cb17-3" data-line-number="3">        <span class="dt">keywordThesaurus =</span> <span class="st">"LTER controlled vocabulary"</span>,</a>
-<a class="sourceLine" id="cb17-4" data-line-number="4">        <span class="dt">keyword =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(<span class="st">"bacteria"</span>,</a>
-<a class="sourceLine" id="cb17-5" data-line-number="5">                    <span class="st">"carnivorous plants"</span>,</a>
-<a class="sourceLine" id="cb17-6" data-line-number="6">                    <span class="st">"genetics"</span>,</a>
-<a class="sourceLine" id="cb17-7" data-line-number="7">                    <span class="st">"thresholds"</span>)</a>
-<a class="sourceLine" id="cb17-8" data-line-number="8">        ),</a>
-<a class="sourceLine" id="cb17-9" data-line-number="9">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(</a>
-<a class="sourceLine" id="cb17-10" data-line-number="10">        <span class="dt">keywordThesaurus =</span> <span class="st">"LTER core area"</span>,</a>
-<a class="sourceLine" id="cb17-11" data-line-number="11">        <span class="dt">keyword =</span>  <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(<span class="st">"populations"</span>, <span class="st">"inorganic nutrients"</span>, <span class="st">"disturbance"</span>)</a>
-<a class="sourceLine" id="cb17-12" data-line-number="12">        ),</a>
-<a class="sourceLine" id="cb17-13" data-line-number="13">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(</a>
-<a class="sourceLine" id="cb17-14" data-line-number="14">        <span class="dt">keywordThesaurus =</span> <span class="st">"HFR default"</span>,</a>
-<a class="sourceLine" id="cb17-15" data-line-number="15">        <span class="dt">keyword =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(<span class="st">"Harvard Forest"</span>, <span class="st">"HFR"</span>, <span class="st">"LTER"</span>, <span class="st">"USA"</span>)</a>
-<a class="sourceLine" id="cb17-16" data-line-number="16">        ))</a></code></pre></div>
+<div class="sourceCode" id="cb15"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb15-1" data-line-number="1">keywordSet &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(</a>
+<a class="sourceLine" id="cb15-2" data-line-number="2">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(</a>
+<a class="sourceLine" id="cb15-3" data-line-number="3">        <span class="dt">keywordThesaurus =</span> <span class="st">"LTER controlled vocabulary"</span>,</a>
+<a class="sourceLine" id="cb15-4" data-line-number="4">        <span class="dt">keyword =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(<span class="st">"bacteria"</span>,</a>
+<a class="sourceLine" id="cb15-5" data-line-number="5">                    <span class="st">"carnivorous plants"</span>,</a>
+<a class="sourceLine" id="cb15-6" data-line-number="6">                    <span class="st">"genetics"</span>,</a>
+<a class="sourceLine" id="cb15-7" data-line-number="7">                    <span class="st">"thresholds"</span>)</a>
+<a class="sourceLine" id="cb15-8" data-line-number="8">        ),</a>
+<a class="sourceLine" id="cb15-9" data-line-number="9">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(</a>
+<a class="sourceLine" id="cb15-10" data-line-number="10">        <span class="dt">keywordThesaurus =</span> <span class="st">"LTER core area"</span>,</a>
+<a class="sourceLine" id="cb15-11" data-line-number="11">        <span class="dt">keyword =</span>  <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(<span class="st">"populations"</span>, <span class="st">"inorganic nutrients"</span>, <span class="st">"disturbance"</span>)</a>
+<a class="sourceLine" id="cb15-12" data-line-number="12">        ),</a>
+<a class="sourceLine" id="cb15-13" data-line-number="13">    <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(</a>
+<a class="sourceLine" id="cb15-14" data-line-number="14">        <span class="dt">keywordThesaurus =</span> <span class="st">"HFR default"</span>,</a>
+<a class="sourceLine" id="cb15-15" data-line-number="15">        <span class="dt">keyword =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(<span class="st">"Harvard Forest"</span>, <span class="st">"HFR"</span>, <span class="st">"LTER"</span>, <span class="st">"USA"</span>)</a>
+<a class="sourceLine" id="cb15-16" data-line-number="16">        ))</a></code></pre></div>
 <p>Lastly, some of the elements needed for <code>eml</code> object can simply be given as text strings.</p>
-<div class="sourceCode" id="cb18"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb18-1" data-line-number="1">pubDate &lt;-<span class="st"> "2012"</span> </a>
-<a class="sourceLine" id="cb18-2" data-line-number="2"></a>
-<a class="sourceLine" id="cb18-3" data-line-number="3">title &lt;-<span class="st"> "Thresholds and Tipping Points in a Sarracenia </span></a>
-<a class="sourceLine" id="cb18-4" data-line-number="4"><span class="st">Microecosystem at Harvard Forest since 2012"</span></a>
-<a class="sourceLine" id="cb18-5" data-line-number="5"></a>
-<a class="sourceLine" id="cb18-6" data-line-number="6">abstract &lt;-<span class="st"> "The primary goal of this project is to determine</span></a>
-<a class="sourceLine" id="cb18-7" data-line-number="7"><span class="st">  experimentally the amount of lead time required to prevent a state</span></a>
-<a class="sourceLine" id="cb18-8" data-line-number="8"><span class="st">change. To achieve this goal, we will (1) experimentally induce state</span></a>
-<a class="sourceLine" id="cb18-9" data-line-number="9"><span class="st">changes in a natural aquatic ecosystem - the Sarracenia microecosystem;</span></a>
-<a class="sourceLine" id="cb18-10" data-line-number="10"><span class="st">(2) use proteomic analysis to identify potential indicators of states</span></a>
-<a class="sourceLine" id="cb18-11" data-line-number="11"><span class="st">and state changes; and (3) test whether we can forestall state changes</span></a>
-<a class="sourceLine" id="cb18-12" data-line-number="12"><span class="st">by experimentally intervening in the system. This work uses state-of-the</span></a>
-<a class="sourceLine" id="cb18-13" data-line-number="13"><span class="st">art molecular tools to identify early warning indicators in the field</span></a>
-<a class="sourceLine" id="cb18-14" data-line-number="14"><span class="st">of aerobic to anaerobic state changes driven by nutrient enrichment</span></a>
-<a class="sourceLine" id="cb18-15" data-line-number="15"><span class="st">in an aquatic ecosystem. The study tests two general hypotheses: (1)</span></a>
-<a class="sourceLine" id="cb18-16" data-line-number="16"><span class="st">proteomic biomarkers can function as reliable indicators of impending</span></a>
-<a class="sourceLine" id="cb18-17" data-line-number="17"><span class="st">state changes and may give early warning before increasing variances</span></a>
-<a class="sourceLine" id="cb18-18" data-line-number="18"><span class="st">and statistical flickering of monitored variables; and (2) well-timed</span></a>
-<a class="sourceLine" id="cb18-19" data-line-number="19"><span class="st">intervention based on proteomic biomarkers can avert future state changes</span></a>
-<a class="sourceLine" id="cb18-20" data-line-number="20"><span class="st">in ecological systems."</span>  </a>
-<a class="sourceLine" id="cb18-21" data-line-number="21"></a>
-<a class="sourceLine" id="cb18-22" data-line-number="22">intellectualRights &lt;-<span class="st"> "This dataset is released to the public and may be freely</span></a>
-<a class="sourceLine" id="cb18-23" data-line-number="23"><span class="st">  downloaded. Please keep the designated Contact person informed of any</span></a>
-<a class="sourceLine" id="cb18-24" data-line-number="24"><span class="st">plans to use the dataset. Consultation or collaboration with the original</span></a>
-<a class="sourceLine" id="cb18-25" data-line-number="25"><span class="st">investigators is strongly encouraged. Publications and data products</span></a>
-<a class="sourceLine" id="cb18-26" data-line-number="26"><span class="st">that make use of the dataset must include proper acknowledgement. For</span></a>
-<a class="sourceLine" id="cb18-27" data-line-number="27"><span class="st">more information on LTER Network data access and use policies, please</span></a>
-<a class="sourceLine" id="cb18-28" data-line-number="28"><span class="st">see: http://www.lternet.edu/data/netpolicy.html."</span></a></code></pre></div>
+<div class="sourceCode" id="cb16"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb16-1" data-line-number="1">pubDate &lt;-<span class="st"> "2012"</span> </a>
+<a class="sourceLine" id="cb16-2" data-line-number="2"></a>
+<a class="sourceLine" id="cb16-3" data-line-number="3">title &lt;-<span class="st"> "Thresholds and Tipping Points in a Sarracenia </span></a>
+<a class="sourceLine" id="cb16-4" data-line-number="4"><span class="st">Microecosystem at Harvard Forest since 2012"</span></a>
+<a class="sourceLine" id="cb16-5" data-line-number="5"></a>
+<a class="sourceLine" id="cb16-6" data-line-number="6">abstract &lt;-<span class="st"> "The primary goal of this project is to determine</span></a>
+<a class="sourceLine" id="cb16-7" data-line-number="7"><span class="st">  experimentally the amount of lead time required to prevent a state</span></a>
+<a class="sourceLine" id="cb16-8" data-line-number="8"><span class="st">change. To achieve this goal, we will (1) experimentally induce state</span></a>
+<a class="sourceLine" id="cb16-9" data-line-number="9"><span class="st">changes in a natural aquatic ecosystem - the Sarracenia microecosystem;</span></a>
+<a class="sourceLine" id="cb16-10" data-line-number="10"><span class="st">(2) use proteomic analysis to identify potential indicators of states</span></a>
+<a class="sourceLine" id="cb16-11" data-line-number="11"><span class="st">and state changes; and (3) test whether we can forestall state changes</span></a>
+<a class="sourceLine" id="cb16-12" data-line-number="12"><span class="st">by experimentally intervening in the system. This work uses state-of-the</span></a>
+<a class="sourceLine" id="cb16-13" data-line-number="13"><span class="st">art molecular tools to identify early warning indicators in the field</span></a>
+<a class="sourceLine" id="cb16-14" data-line-number="14"><span class="st">of aerobic to anaerobic state changes driven by nutrient enrichment</span></a>
+<a class="sourceLine" id="cb16-15" data-line-number="15"><span class="st">in an aquatic ecosystem. The study tests two general hypotheses: (1)</span></a>
+<a class="sourceLine" id="cb16-16" data-line-number="16"><span class="st">proteomic biomarkers can function as reliable indicators of impending</span></a>
+<a class="sourceLine" id="cb16-17" data-line-number="17"><span class="st">state changes and may give early warning before increasing variances</span></a>
+<a class="sourceLine" id="cb16-18" data-line-number="18"><span class="st">and statistical flickering of monitored variables; and (2) well-timed</span></a>
+<a class="sourceLine" id="cb16-19" data-line-number="19"><span class="st">intervention based on proteomic biomarkers can avert future state changes</span></a>
+<a class="sourceLine" id="cb16-20" data-line-number="20"><span class="st">in ecological systems."</span>  </a>
+<a class="sourceLine" id="cb16-21" data-line-number="21"></a>
+<a class="sourceLine" id="cb16-22" data-line-number="22">intellectualRights &lt;-<span class="st"> "This dataset is released to the public and may be freely</span></a>
+<a class="sourceLine" id="cb16-23" data-line-number="23"><span class="st">  downloaded. Please keep the designated Contact person informed of any</span></a>
+<a class="sourceLine" id="cb16-24" data-line-number="24"><span class="st">plans to use the dataset. Consultation or collaboration with the original</span></a>
+<a class="sourceLine" id="cb16-25" data-line-number="25"><span class="st">investigators is strongly encouraged. Publications and data products</span></a>
+<a class="sourceLine" id="cb16-26" data-line-number="26"><span class="st">that make use of the dataset must include proper acknowledgement. For</span></a>
+<a class="sourceLine" id="cb16-27" data-line-number="27"><span class="st">more information on LTER Network data access and use policies, please</span></a>
+<a class="sourceLine" id="cb16-28" data-line-number="28"><span class="st">see: http://www.lternet.edu/data/netpolicy.html."</span></a></code></pre></div>
 <p>Many of these text fields can instead be read in from an external file that has richer formatting, such as we did with the <code><a href="../reference/set_methods.html">set_methods()</a></code> step. Any text field containing a slot named <code>section</code> can import text data from a MS Word <code>.docx</code> file, markdown file, or other file format recognized by <a href="http://pandoc.org">Pandoc</a> into that element. For instance, here we import the same paragraph of text shown above for <code>abstract</code> from an external file (this time, a markdown-formatted file) instead:</p>
-<div class="sourceCode" id="cb19"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb19-1" data-line-number="1">abstract_file &lt;-<span class="st">  </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/system.file">system.file</a></span>(<span class="st">"examples/hf205-abstract.md"</span>, <span class="dt">package =</span> <span class="st">"EML"</span>)</a>
-<a class="sourceLine" id="cb19-2" data-line-number="2">abstract &lt;-<span class="st"> </span><span class="kw"><a href="../reference/set_TextType.html">set_TextType</a></span>(abstract_file)</a></code></pre></div>
+<div class="sourceCode" id="cb17"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb17-1" data-line-number="1">abstract_file &lt;-<span class="st">  </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/system.file">system.file</a></span>(<span class="st">"examples/hf205-abstract.md"</span>, <span class="dt">package =</span> <span class="st">"EML"</span>)</a>
+<a class="sourceLine" id="cb17-2" data-line-number="2">abstract &lt;-<span class="st"> </span><span class="kw"><a href="../reference/set_TextType.html">set_TextType</a></span>(abstract_file)</a></code></pre></div>
 <p>We are now ready to add each of these elements we have created so far into our <code>dataset</code> element, like so:</p>
-<div class="sourceCode" id="cb20"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb20-1" data-line-number="1">dataset &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(</a>
-<a class="sourceLine" id="cb20-2" data-line-number="2">               <span class="dt">title =</span> title,</a>
-<a class="sourceLine" id="cb20-3" data-line-number="3">               <span class="dt">creator =</span> aaron,</a>
-<a class="sourceLine" id="cb20-4" data-line-number="4">               <span class="dt">pubDate =</span> pubDate,</a>
-<a class="sourceLine" id="cb20-5" data-line-number="5">               <span class="dt">intellectualRights =</span> intellectualRights,</a>
-<a class="sourceLine" id="cb20-6" data-line-number="6">               <span class="dt">abstract =</span> abstract,</a>
-<a class="sourceLine" id="cb20-7" data-line-number="7">               <span class="dt">associatedParty =</span> associatedParty,</a>
-<a class="sourceLine" id="cb20-8" data-line-number="8">               <span class="dt">keywordSet =</span> keywordSet,</a>
-<a class="sourceLine" id="cb20-9" data-line-number="9">               <span class="dt">coverage =</span> coverage,</a>
-<a class="sourceLine" id="cb20-10" data-line-number="10">               <span class="dt">contact =</span> contact,</a>
-<a class="sourceLine" id="cb20-11" data-line-number="11">               <span class="dt">methods =</span> methods,</a>
-<a class="sourceLine" id="cb20-12" data-line-number="12">               <span class="dt">dataTable =</span> dataTable)</a></code></pre></div>
+<div class="sourceCode" id="cb18"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb18-1" data-line-number="1">dataset &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(</a>
+<a class="sourceLine" id="cb18-2" data-line-number="2">               <span class="dt">title =</span> title,</a>
+<a class="sourceLine" id="cb18-3" data-line-number="3">               <span class="dt">creator =</span> aaron,</a>
+<a class="sourceLine" id="cb18-4" data-line-number="4">               <span class="dt">pubDate =</span> pubDate,</a>
+<a class="sourceLine" id="cb18-5" data-line-number="5">               <span class="dt">intellectualRights =</span> intellectualRights,</a>
+<a class="sourceLine" id="cb18-6" data-line-number="6">               <span class="dt">abstract =</span> abstract,</a>
+<a class="sourceLine" id="cb18-7" data-line-number="7">               <span class="dt">associatedParty =</span> associatedParty,</a>
+<a class="sourceLine" id="cb18-8" data-line-number="8">               <span class="dt">keywordSet =</span> keywordSet,</a>
+<a class="sourceLine" id="cb18-9" data-line-number="9">               <span class="dt">coverage =</span> coverage,</a>
+<a class="sourceLine" id="cb18-10" data-line-number="10">               <span class="dt">contact =</span> contact,</a>
+<a class="sourceLine" id="cb18-11" data-line-number="11">               <span class="dt">methods =</span> methods,</a>
+<a class="sourceLine" id="cb18-12" data-line-number="12">               <span class="dt">dataTable =</span> dataTable)</a></code></pre></div>
 <p>With the <code>dataset</code> in place, we are ready to declare our root <code>eml</code> element. In addition to our <code>dataset</code> element we have already built, all we need is a packageId code and the system on which it is based. Here we have generated a unique id using the standard <code>uuid</code> algorithm, which is available in the R package <code>uuid</code>.</p>
-<div class="sourceCode" id="cb21"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb21-1" data-line-number="1">eml &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(</a>
-<a class="sourceLine" id="cb21-2" data-line-number="2">           <span class="dt">packageId =</span> uuid<span class="op">::</span><span class="kw"><a href="https://www.rdocumentation.org/packages/uuid/topics/UUIDgenerate">UUIDgenerate</a></span>(),</a>
-<a class="sourceLine" id="cb21-3" data-line-number="3">           <span class="dt">system =</span> <span class="st">"uuid"</span>, <span class="co"># type of identifier</span></a>
-<a class="sourceLine" id="cb21-4" data-line-number="4">           <span class="dt">dataset =</span> dataset)</a></code></pre></div>
+<div class="sourceCode" id="cb19"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb19-1" data-line-number="1">eml &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(</a>
+<a class="sourceLine" id="cb19-2" data-line-number="2">           <span class="dt">packageId =</span> uuid<span class="op">::</span><span class="kw"><a href="https://www.rdocumentation.org/packages/uuid/topics/UUIDgenerate">UUIDgenerate</a></span>(),</a>
+<a class="sourceLine" id="cb19-3" data-line-number="3">           <span class="dt">system =</span> <span class="st">"uuid"</span>, <span class="co"># type of identifier</span></a>
+<a class="sourceLine" id="cb19-4" data-line-number="4">           <span class="dt">dataset =</span> dataset)</a></code></pre></div>
 <p>With our <code>eml</code> object fully constructed in R, we can now check that it is valid, conforming to all criteria set forth in the EML Schema. This will ensure that other researchers and other software can readily parse and understand the contents of our metadata file:</p>
-<div class="sourceCode" id="cb22"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb22-1" data-line-number="1"><span class="kw"><a href="../reference/write_eml.html">write_eml</a></span>(eml, <span class="st">"eml.xml"</span>)</a></code></pre></div>
-<div class="sourceCode" id="cb23"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb23-1" data-line-number="1"><span class="kw"><a href="../reference/eml_validate.html">eml_validate</a></span>(<span class="st">"eml.xml"</span>)</a></code></pre></div>
+<div class="sourceCode" id="cb20"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb20-1" data-line-number="1"><span class="kw"><a href="../reference/write_eml.html">write_eml</a></span>(eml, <span class="st">"eml.xml"</span>)</a></code></pre></div>
+<div class="sourceCode" id="cb21"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb21-1" data-line-number="1"><span class="kw"><a href="../reference/eml_validate.html">eml_validate</a></span>(<span class="st">"eml.xml"</span>)</a></code></pre></div>
 <pre><code>## [1] TRUE
 ## attr(,"errors")
 ## character(0)</code></pre>
@@ -399,7 +397,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
 </div>

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -70,7 +70,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -99,6 +99,9 @@
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -142,7 +145,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/articles/working-with-units.html
+++ b/docs/articles/working-with-units.html
@@ -37,7 +37,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -67,6 +67,9 @@
     </li>
   </ul>
 </li>
+<li>
+  <a href="../news/index.html">Changelog</a>
+</li>
       </ul>
 <ul class="nav navbar-nav navbar-right">
 <li>
@@ -90,7 +93,7 @@
       <h1>Working with Units</h1>
                         <h4 class="author">Carl Boettiger</h4>
             
-            <h4 class="date">2019-01-30</h4>
+            <h4 class="date">2019-05-19</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/ropensci/EML/blob/master/vignettes/working-with-units.Rmd"><code>vignettes/working-with-units.Rmd</code></a></small>
       <div class="hidden name"><code>working-with-units.Rmd</code></div>
@@ -121,7 +124,7 @@
 <p>Start with a minimal EML document</p>
 <div class="sourceCode" id="cb3"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb3-1" data-line-number="1">me &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(<span class="dt">individualName =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(<span class="dt">givenName =</span> <span class="st">"Carl"</span>, <span class="dt">surName =</span> <span class="st">"Boettiger"</span>))</a>
 <a class="sourceLine" id="cb3-2" data-line-number="2">my_eml &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(<span class="dt">dataset =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(</a>
-<a class="sourceLine" id="cb3-3" data-line-number="3">              <span class="dt">title =</span> <span class="st">"A Mimimal Valid EML Dataset"</span>,</a>
+<a class="sourceLine" id="cb3-3" data-line-number="3">              <span class="dt">title =</span> <span class="st">"A Minimal Valid EML Dataset"</span>,</a>
 <a class="sourceLine" id="cb3-4" data-line-number="4">              <span class="dt">creator =</span> me,</a>
 <a class="sourceLine" id="cb3-5" data-line-number="5">              <span class="dt">contact =</span> me),</a>
 <a class="sourceLine" id="cb3-6" data-line-number="6">              <span class="dt">additionalMetadata =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(<span class="dt">metadata =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(</a>
@@ -133,13 +136,13 @@
 <pre><code>## [1] TRUE
 ## attr(,"errors")
 ## character(0)</code></pre>
-<p>Note: Custom units are widely missunderstood and missused in EML. See examples from <a href="https://gist.github.com/amoeba/67a23818dfca49904c7a54b0632d76bc#file-all-arcticdata-customUnits">custom-units</a></p>
+<p>Note: Custom units are widely misunderstood and misused in EML. See examples from <a href="https://gist.github.com/amoeba/67a23818dfca49904c7a54b0632d76bc#file-all-arcticdata-customUnits">custom-units</a></p>
 </div>
 <div id="reading-eml-parsing-unit-information-including-custom-unit-types" class="section level2">
 <h2 class="hasAnchor">
 <a href="#reading-eml-parsing-unit-information-including-custom-unit-types" class="anchor"></a>Reading EML: parsing unit information, including custom unit types</h2>
 <p>Let us start by examining the numeric attributes in an example EML file. First we read in the file:</p>
-<div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb6-1" data-line-number="1">f &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/system.file">system.file</a></span>(<span class="st">"tests"</span>, <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/options">options</a></span>(<span class="st">"emld_db"</span>), <span class="st">"eml-datasetWithUnits.xml"</span>, <span class="dt">package =</span> <span class="st">"emld"</span>)</a>
+<div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb6-1" data-line-number="1">f &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/system.file">system.file</a></span>(<span class="st">"tests"</span>, emld<span class="op">::</span><span class="kw"><a href="https://www.rdocumentation.org/packages/emld/topics/eml_version">eml_version</a></span>(), <span class="st">"eml-datasetWithUnits.xml"</span>, <span class="dt">package =</span> <span class="st">"emld"</span>)</a>
 <a class="sourceLine" id="cb6-2" data-line-number="2">eml &lt;-<span class="st"> </span><span class="kw"><a href="../reference/read_eml.html">read_eml</a></span>(f)</a></code></pre></div>
 <p>We extract the <code>attributeList</code>, and examine the numeric attributes (e.g. those which have units):</p>
 </div>
@@ -165,7 +168,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
 </div>

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -70,7 +70,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -99,6 +99,9 @@
       <a href="articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -145,6 +148,10 @@
         <p><strong>Maëlle Salmon</strong>. Contributor. <a href='https://orcid.org/0000-0002-2815-0399' target='orcid.widget'><img src='https://members.orcid.org/sites/default/files/vector_iD_icon.svg' class='orcid' alt='ORCID' height='16'></a>
         </p>
       </li>
+      <li>
+        <p><strong>Jeanette Clark</strong>. Contributor. <a href='https://orcid.org/0000-0003-4703-1974' target='orcid.widget'><img src='https://members.orcid.org/sites/default/files/vector_iD_icon.svg' class='orcid' alt='ORCID' height='16'></a>
+        </p>
+      </li>
     </ul>
 
   </div>
@@ -158,7 +165,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Create and Manipulate Data using the Ecological Metadata Language • EML</title>
+<title>Read and Write Ecological Metadata Language Files • EML</title>
 <!-- favicons --><link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
 <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
 <link rel="apple-touch-icon" type="image/png" sizes="180x180" href="apple-touch-icon.png">
@@ -15,8 +15,11 @@
 <!-- jquery --><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script><!-- Bootstrap --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script><!-- Font Awesome icons --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous">
 <!-- clipboard.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script><!-- sticky kit --><script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script><!-- pkgdown --><link href="pkgdown.css" rel="stylesheet">
-<script src="pkgdown.js"></script><meta property="og:title" content="Create and Manipulate Data using the Ecological Metadata Language">
-<meta property="og:description" content="Read and write Ecological Metadata Language files">
+<script src="pkgdown.js"></script><meta property="og:title" content="Read and Write Ecological Metadata Language Files">
+<meta property="og:description" content="Work with Ecological Metadata Language ('EML') files. 
+    'EML' is a widely used metadata standard in the ecological and
+    environmental sciences, described in Jones et al. (2006),
+    &lt;doi:10.1146/annurev.ecolsys.37.091305.110031&gt;.">
 <meta property="og:image" content="/logo.png">
 <meta name="twitter:card" content="summary">
 <!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script><!--[if lt IE 9]>
@@ -37,7 +40,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -66,6 +69,9 @@
       <a href="articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="news/index.html">Changelog</a>
 </li>
       </ul>
 <ul class="nav navbar-nav navbar-right">
@@ -96,11 +102,11 @@
 </h1></div>
 <p><a href="https://www.tidyverse.org/lifecycle/#maturing"><img src="https://img.shields.io/badge/lifecycle-maturing-blue.svg" alt="lifecycle"></a> <a href="https://travis-ci.org/ropensci/EML"><img src="https://travis-ci.org/ropensci/EML.svg?branch=master" alt="Build Status"></a> <a href="https://ci.appveyor.com/project/cboettig/eml"><img src="https://ci.appveyor.com/api/projects/status/u2gw24yfkvxgny96?svg=true" alt="Windows build status"></a> <a href="https://codecov.io/gh/ropensci/EML"><img src="https://codecov.io/gh/ropensci/EML/branch/master/graph/badge.svg" alt="codecov"></a> <a href="https://cran.r-project.org/package=EML"><img src="https://www.r-pkg.org/badges/version/EML" alt="CRAN status"></a> <img src="http://cranlogs.r-pkg.org/badges/grand-total/RNeXML" alt="downloads"><a href="https://zenodo.org/badge/latestdoi/10894022"><img src="https://zenodo.org/badge/10894022.svg" alt="DOI"></a></p>
 <!-- README.md is generated from README.Rmd. Please edit that file -->
-<p>EML is a widely used metadata standard in the ecological and environmental sciences. We strongly recommend that interested users visit the <a href="https://knb.ecoinformatics.org/#external//emlparser/docs/index.html">EML Homepage</a> for an introduction and thorough documentation of the standard. Additionally, the scientific article <em><a href="http://doi.org/10.1146/annurev.ecolsys.37.091305.110031">The New Bioinformatics: Integrating Ecological Data from the Gene to the Biosphere (Jones et al 2006)</a></em> provides an excellent introduction into the role EML plays in building metadata-driven data repositories to address the needs of highly hetergenous data that cannot be easily reduced to a traditional vertically integrated database. At this time, the <code>EML</code> R package provides support for the serializing and parsing of all low-level EML concepts, but still assumes some familiarity with the EML standard, particularly for users seeking to create their own EML files. We hope to add more higher-level functions which will make such familiarity less essential in future development.</p>
+<p>EML is a widely used metadata standard in the ecological and environmental sciences. We strongly recommend that interested users visit the <a href="https://knb.ecoinformatics.org/#external//emlparser/docs/index.html">EML Homepage</a> for an introduction and thorough documentation of the standard. Additionally, the scientific article <em><a href="http://doi.org/10.1146/annurev.ecolsys.37.091305.110031">The New Bioinformatics: Integrating Ecological Data from the Gene to the Biosphere (Jones et al 2006)</a></em> provides an excellent introduction into the role EML plays in building metadata-driven data repositories to address the needs of highly heterogeneous data that cannot be easily reduced to a traditional vertically integrated database. At this time, the <code>EML</code> R package provides support for the serializing and parsing of all low-level EML concepts, but still assumes some familiarity with the EML standard, particularly for users seeking to create their own EML files. We hope to add more higher-level functions which will make such familiarity less essential in future development.</p>
 <div id="notes-on-the-eml-v2-0-release" class="section level2">
 <h2 class="hasAnchor">
 <a href="#notes-on-the-eml-v2-0-release" class="anchor"></a>Notes on the EML v2.0 Release</h2>
-<p><code>EML</code> v2.0 is a complete re-write which aims to provide both a drop-in replacement for the higher-level functions of the existing EML package while also providing additional functionality. This new <code>EML</code> version uses only simple and familiar list structures (S3 classes) instead of the more cumbersome use of S4 found in the original <code>EML</code>. While the higher-level functions are identical, this makes it easier to for most users and developers to work with <code>eml</code> objects and also to write their own functions for creating and manipulating EML objects. Under the hood, <code>EML</code> relies on the <a href="https://github.com/cboettig/emld">emld</a> package, which uses a Linked Data representation for EML. It is this approach which lets us combine the simplicity of lists with the specificy required by the XML schema.</p>
+<p><code>EML</code> v2.0 is a complete re-write which aims to provide both a drop-in replacement for the higher-level functions of the existing EML package while also providing additional functionality. This new <code>EML</code> version uses only simple and familiar list structures (S3 classes) instead of the more cumbersome use of S4 found in the original <code>EML</code>. While the higher-level functions are identical, this makes it easier to for most users and developers to work with <code>eml</code> objects and also to write their own functions for creating and manipulating EML objects. Under the hood, <code>EML</code> relies on the <a href="https://github.com/cboettig/emld">emld</a> package, which uses a Linked Data representation for EML. It is this approach which lets us combine the simplicity of lists with the specificity required by the XML schema.</p>
 <p>This revision also supports the upcoming release of the EML 2.2 specification.</p>
 </div>
 </div>
@@ -113,7 +119,7 @@
 <a href="#a-minimal-valid-eml-document" class="anchor"></a>A minimal valid EML document:</h2>
 <div class="sourceCode" id="cb2"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb2-1" data-line-number="1">me &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(<span class="dt">individualName =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(<span class="dt">givenName =</span> <span class="st">"Carl"</span>, <span class="dt">surName =</span> <span class="st">"Boettiger"</span>))</a>
 <a class="sourceLine" id="cb2-2" data-line-number="2">my_eml &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(<span class="dt">dataset =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(</a>
-<a class="sourceLine" id="cb2-3" data-line-number="3">              <span class="dt">title =</span> <span class="st">"A Mimimal Valid EML Dataset"</span>,</a>
+<a class="sourceLine" id="cb2-3" data-line-number="3">              <span class="dt">title =</span> <span class="st">"A Minimal Valid EML Dataset"</span>,</a>
 <a class="sourceLine" id="cb2-4" data-line-number="4">              <span class="dt">creator =</span> me,</a>
 <a class="sourceLine" id="cb2-5" data-line-number="5">              <span class="dt">contact =</span> me)</a>
 <a class="sourceLine" id="cb2-6" data-line-number="6">            )</a>
@@ -270,10 +276,12 @@
 <div id="setting-the-version" class="section level2">
 <h2 class="hasAnchor">
 <a href="#setting-the-version" class="anchor"></a>Setting the version</h2>
-<p>EML will use the latest EML specification by default. To switch to a different version, set the option <code>emld_db</code>, like so:</p>
-<div class="sourceCode" id="cb15"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb15-1" data-line-number="1"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/options">options</a></span>(<span class="st">"emld_db"</span> =<span class="st"> "eml-2.1.1"</span>)</a></code></pre></div>
+<p>EML will use the latest EML specification by default. To switch to a different version, use <code><a href="https://www.rdocumentation.org/packages/emld/topics/eml_version">emld::eml_version()</a></code></p>
+<div class="sourceCode" id="cb15"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb15-1" data-line-number="1">emld<span class="op">::</span><span class="kw"><a href="https://www.rdocumentation.org/packages/emld/topics/eml_version">eml_version</a></span>(<span class="st">"eml-2.1.1"</span>)</a>
+<a class="sourceLine" id="cb15-2" data-line-number="2"><span class="co">#&gt; [1] "eml-2.1.1"</span></a></code></pre></div>
 <p>Switch back to the 2.2.0 release:</p>
-<div class="sourceCode" id="cb16"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb16-1" data-line-number="1"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/options">options</a></span>(<span class="st">"emld_db"</span> =<span class="st"> "eml-2.2.0"</span>)</a></code></pre></div>
+<div class="sourceCode" id="cb16"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb16-1" data-line-number="1">emld<span class="op">::</span><span class="kw"><a href="https://www.rdocumentation.org/packages/emld/topics/eml_version">eml_version</a></span>(<span class="st">"eml-2.2.0"</span>)</a>
+<a class="sourceLine" id="cb16-2" data-line-number="2"><span class="co">#&gt; [1] "eml-2.2.0"</span></a></code></pre></div>
 </div>
 </div>
   </div>
@@ -316,7 +324,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
 </div>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>eml — eml • EML</title>
+<title>Changelog • EML</title>
 
 <!-- favicons -->
 <link rel="icon" type="image/png" sizes="16x16" href="../favicon-16x16.png">
@@ -37,9 +37,7 @@
 
 
 
-<meta property="og:title" content="eml — eml" />
-
-<meta property="og:description" content="eml" />
+<meta property="og:title" content="Changelog" />
 
 <meta property="og:image" content="/logo.png" />
 <meta name="twitter:card" content="summary" />
@@ -59,7 +57,7 @@
   </head>
 
   <body>
-    <div class="container template-reference-topic">
+    <div class="container template-news">
       <header>
       <div class="navbar navbar-default navbar-fixed-top" role="navigation">
   <div class="container">
@@ -126,32 +124,33 @@
 <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
-    <h1>eml</h1>
-    <small class="dont-index">Source: <a href='https://github.com/ropensci/EML/blob/master/R/template_constructor.R'><code>R/template_constructor.R</code></a></small>
-    <div class="hidden name"><code>eml.Rd</code></div>
+      <h1>Changelog <small></small></h1>
+      <small>Source: <a href='https://github.com/ropensci/EML/blob/master/NEWS.md'><code>NEWS.md</code></a></small>
     </div>
 
-    <div class="ref-description">
-    
-    <p>eml</p>
-    
-    </div>
-
-        
-    <h2 class="hasAnchor" id="format"><a class="anchor" href="#format"></a>Format</h2>
-
-    <p>A list with constructor functions</p>
-    
-
+    <div id="eml-2-0-0" class="section level1">
+<h1 class="page-header">
+<a href="#eml-2-0-0" class="anchor"></a>EML 2.0.0<small> 2019-04-23 </small>
+</h1>
+<ul>
+<li>
+<p>EML 2.0.0 is a ground-up rewrite of EML 1.x package. The primary difference is that EML 2.0.0 is built on S3 (list) objects instead of S4 object system. This makes the package interface easier to use and extend. Under the hood, this approach relies on the <code>emld</code> package, which uses a JSON-LD representation of EML which provides a natural translation into the list-based format.</p>
+<p>While most high level functions for creating EML have been preserved, the change to S3 means that this package will not be backwards-compatible with many scripts which relied on the S4 system.</p>
+</li>
+<li><p>Added a <code>NEWS.md</code> file to track changes to the package.</p></li>
+</ul>
+</div>
   </div>
+
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
-    <h2>Contents</h2>
-    <ul class="nav nav-pills nav-stacked">
-      
-      <li><a href="#format">Format</a></li>
-          </ul>
-
+    <div id="tocnav">
+      <h2>Contents</h2>
+      <ul class="nav nav-pills nav-stacked">
+        <li><a href="#eml-2-0-0">2.0.0</a></li>
+      </ul>
+    </div>
   </div>
+
 </div>
 
       <footer>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -1,6 +1,6 @@
 pandoc: 2.3.1
-pkgdown: 1.3.0.9000
-pkgdown_sha: fa9b7502e80401db4b410086b0a8f6ab444f0c66
+pkgdown: 1.3.0
+pkgdown_sha: ~
 articles:
   creating-EML: creating-EML.html
   working-with-units: working-with-units.html

--- a/docs/reference/build_factors.html
+++ b/docs/reference/build_factors.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -101,6 +101,9 @@
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -166,7 +169,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/build_units_table.html
+++ b/docs/reference/build_units_table.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -101,6 +101,9 @@
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -166,7 +169,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/detect_delim.html
+++ b/docs/reference/detect_delim.html
@@ -73,7 +73,7 @@ be able to automate its recordDelimiter argument." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -102,6 +102,9 @@ be able to automate its recordDelimiter argument." />
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -175,7 +178,7 @@ searching</p></td>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/eml_get.html
+++ b/docs/reference/eml_get.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -101,6 +101,9 @@
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -161,7 +164,7 @@ If multiple occurrences are found, will extract all</p></td>
     
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
-    <pre class="examples"><div class='input'><span class='no'>f</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/system.file'>system.file</a></span>(<span class='st'>"tests"</span>, <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/options'>options</a></span>(<span class='st'>"emld_db"</span>), <span class='st'>"eml-datasetWithUnits.xml"</span>, <span class='kw'>package</span> <span class='kw'>=</span> <span class='st'>"emld"</span>)
+    <pre class="examples"><div class='input'><span class='no'>f</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/system.file'>system.file</a></span>(<span class='st'>"tests"</span>, <span class='kw pkg'>emld</span><span class='kw ns'>::</span><span class='fu'><a href='https://www.rdocumentation.org/packages/emld/topics/eml_version'>eml_version</a></span>(), <span class='st'>"eml-datasetWithUnits.xml"</span>, <span class='kw'>package</span> <span class='kw'>=</span> <span class='st'>"emld"</span>)
 <span class='no'>eml</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='read_eml.html'>read_eml</a></span>(<span class='no'>f</span>)
 <span class='fu'>eml_get</span>(<span class='no'>eml</span>, <span class='st'>"physical"</span>)</div><div class='output co'>#&gt; characterEncoding: ASCII
 #&gt; dataFormat:
@@ -415,7 +418,7 @@ If multiple occurrences are found, will extract all</p></td>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/eml_validate.html
+++ b/docs/reference/eml_validate.html
@@ -74,7 +74,7 @@ as defined by the XSD specification" />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -103,6 +103,9 @@ as defined by the XSD specification" />
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -206,7 +209,7 @@ as defined by the XSD specification</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/get_attributes.html
+++ b/docs/reference/get_attributes.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -101,6 +101,9 @@
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -163,7 +166,7 @@ and thus infer the correct metadata.</p>
     
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
-    <pre class="examples"><div class='input'><span class='no'>f</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/system.file'>system.file</a></span>(<span class='st'>"tests"</span>, <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/options'>options</a></span>(<span class='st'>"emld_db"</span>),
+    <pre class="examples"><div class='input'><span class='no'>f</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/system.file'>system.file</a></span>(<span class='st'>"tests"</span>, <span class='kw pkg'>emld</span><span class='kw ns'>::</span><span class='fu'><a href='https://www.rdocumentation.org/packages/emld/topics/eml_version'>eml_version</a></span>(),
   <span class='st'>"eml-datasetWithAttributelevelMethods.xml"</span>, <span class='kw'>package</span> <span class='kw'>=</span> <span class='st'>"emld"</span>)
 <span class='no'>eml</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='read_eml.html'>read_eml</a></span>(<span class='no'>f</span>)
 <span class='fu'>get_attributes</span>(<span class='no'>eml</span>$<span class='no'>dataset</span>$<span class='no'>dataTable</span>$<span class='no'>attributeList</span>)</div><div class='output co'>#&gt; $attributes
@@ -245,7 +248,7 @@ and thus infer the correct metadata.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/get_numberType.html
+++ b/docs/reference/get_numberType.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -101,6 +101,9 @@
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -176,7 +179,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/get_unitList.html
+++ b/docs/reference/get_unitList.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -101,6 +101,9 @@
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -161,7 +164,7 @@ when defining metadata, e.g. in the table passed to `set_attributes()`.</p>
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><div class='input'>
 # Read in additional units defined in a EML file
-</div><div class='input'><span class='no'>f</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/system.file'>system.file</a></span>(<span class='st'>"tests"</span>, <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/options'>options</a></span>(<span class='st'>"emld_db"</span>),
+</div><div class='input'><span class='no'>f</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/system.file'>system.file</a></span>(<span class='st'>"tests"</span>, <span class='kw pkg'>emld</span><span class='kw ns'>::</span><span class='fu'><a href='https://www.rdocumentation.org/packages/emld/topics/eml_version'>eml_version</a></span>(),
   <span class='st'>"eml-datasetWithUnits.xml"</span>,
   <span class='kw'>package</span> <span class='kw'>=</span> <span class='st'>"emld"</span>
 )
@@ -394,52 +397,52 @@ when defining metadata, e.g. in the table passed to `set_attributes()`.</p>
 #&gt; 25                            mass
 #&gt; 26                            mass
 #&gt; 27                            mass
-#&gt; 28                            NULL
-#&gt; 29                            NULL
-#&gt; 30                            NULL
-#&gt; 31                            NULL
-#&gt; 32                            NULL
-#&gt; 33                            NULL
-#&gt; 34                            NULL
-#&gt; 35                            NULL
-#&gt; 36                            NULL
-#&gt; 37                            NULL
-#&gt; 38                            NULL
-#&gt; 39                            NULL
-#&gt; 40                            NULL
-#&gt; 41                            NULL
-#&gt; 42                            NULL
-#&gt; 43                            NULL
-#&gt; 44                            NULL
-#&gt; 45                            NULL
-#&gt; 46                            NULL
-#&gt; 47                            NULL
-#&gt; 48                            NULL
-#&gt; 49                            NULL
-#&gt; 50                            NULL
-#&gt; 51                            NULL
-#&gt; 52                            NULL
-#&gt; 53                            NULL
-#&gt; 54                            NULL
-#&gt; 55                            NULL
-#&gt; 56                            NULL
-#&gt; 57                            NULL
-#&gt; 58                            NULL
-#&gt; 59                            NULL
-#&gt; 60                            NULL
-#&gt; 61                            NULL
-#&gt; 62                            NULL
-#&gt; 63                            NULL
-#&gt; 64                            NULL
+#&gt; 28                            &lt;NA&gt;
+#&gt; 29                            &lt;NA&gt;
+#&gt; 30                            &lt;NA&gt;
+#&gt; 31                            &lt;NA&gt;
+#&gt; 32                            &lt;NA&gt;
+#&gt; 33                            &lt;NA&gt;
+#&gt; 34                            &lt;NA&gt;
+#&gt; 35                            &lt;NA&gt;
+#&gt; 36                            &lt;NA&gt;
+#&gt; 37                            &lt;NA&gt;
+#&gt; 38                            &lt;NA&gt;
+#&gt; 39                            &lt;NA&gt;
+#&gt; 40                            &lt;NA&gt;
+#&gt; 41                            &lt;NA&gt;
+#&gt; 42                            &lt;NA&gt;
+#&gt; 43                            &lt;NA&gt;
+#&gt; 44                            &lt;NA&gt;
+#&gt; 45                            &lt;NA&gt;
+#&gt; 46                            &lt;NA&gt;
+#&gt; 47                            &lt;NA&gt;
+#&gt; 48                            &lt;NA&gt;
+#&gt; 49                            &lt;NA&gt;
+#&gt; 50                            &lt;NA&gt;
+#&gt; 51                            &lt;NA&gt;
+#&gt; 52                            &lt;NA&gt;
+#&gt; 53                            &lt;NA&gt;
+#&gt; 54                            &lt;NA&gt;
+#&gt; 55                            &lt;NA&gt;
+#&gt; 56                            &lt;NA&gt;
+#&gt; 57                            &lt;NA&gt;
+#&gt; 58                            &lt;NA&gt;
+#&gt; 59                            &lt;NA&gt;
+#&gt; 60                            &lt;NA&gt;
+#&gt; 61                            &lt;NA&gt;
+#&gt; 62                            &lt;NA&gt;
+#&gt; 63                            &lt;NA&gt;
+#&gt; 64                            &lt;NA&gt;
 #&gt; 65                          volume
 #&gt; 66                          volume
 #&gt; 67                          volume
 #&gt; 68                          volume
-#&gt; 69                            NULL
-#&gt; 70                            NULL
+#&gt; 69                            &lt;NA&gt;
+#&gt; 70                            &lt;NA&gt;
 #&gt; 71                          volume
 #&gt; 72                          volume
-#&gt; 73                            NULL
+#&gt; 73                            &lt;NA&gt;
 #&gt; 74                           angle
 #&gt; 75                           angle
 #&gt; 76                           angle
@@ -759,23 +762,23 @@ when defining metadata, e.g. in the table passed to `set_attributes()`.</p>
 #&gt; 194                                                                    micrograms per gram
 #&gt; 195                                                 cubic centimeters per cubic centimeter
 #&gt;     abbreviation       multiplierToSI                          parentSI
-#&gt; 1           NULL                 NULL                              NULL
-#&gt; 2            sec                    1                              NULL
-#&gt; 3              m                    1                              NULL
-#&gt; 4             kg                    1                              NULL
-#&gt; 5              K                    1                              NULL
-#&gt; 6              C                    1                              NULL
-#&gt; 7              A                    1                              NULL
-#&gt; 8            mol                    1                              NULL
-#&gt; 9             cd                    1                              NULL
-#&gt; 10          NULL                 NULL                              NULL
-#&gt; 11            m³                    1                              NULL
-#&gt; 12          NULL                   60                            second
-#&gt; 13          NULL                 3600                            second
-#&gt; 14          NULL                86400                            second
-#&gt; 15          NULL               604800                            second
-#&gt; 16          NULL             31536000                            second
-#&gt; 17          NULL             31622400                            second
+#&gt; 1           &lt;NA&gt;                 &lt;NA&gt;                              &lt;NA&gt;
+#&gt; 2            sec                    1                              &lt;NA&gt;
+#&gt; 3              m                    1                              &lt;NA&gt;
+#&gt; 4             kg                    1                              &lt;NA&gt;
+#&gt; 5              K                    1                              &lt;NA&gt;
+#&gt; 6              C                    1                              &lt;NA&gt;
+#&gt; 7              A                    1                              &lt;NA&gt;
+#&gt; 8            mol                    1                              &lt;NA&gt;
+#&gt; 9             cd                    1                              &lt;NA&gt;
+#&gt; 10          &lt;NA&gt;                 &lt;NA&gt;                              &lt;NA&gt;
+#&gt; 11            m³                    1                              &lt;NA&gt;
+#&gt; 12          &lt;NA&gt;                   60                            second
+#&gt; 13          &lt;NA&gt;                 3600                            second
+#&gt; 14          &lt;NA&gt;                86400                            second
+#&gt; 15          &lt;NA&gt;               604800                            second
+#&gt; 16          &lt;NA&gt;             31536000                            second
+#&gt; 17          &lt;NA&gt;             31622400                            second
 #&gt; 18            ng       0.000000000001                          kilogram
 #&gt; 19            μg          0.000000001                          kilogram
 #&gt; 20            mg             0.000001                          kilogram
@@ -805,12 +808,12 @@ when defining metadata, e.g. in the table passed to `set_attributes()`.</p>
 #&gt; 44          usft               0.3048                             meter
 #&gt; 45            ft               0.3048                             meter
 #&gt; 46          gcft            0.3047997                             meter
-#&gt; 47          NULL               1.8288                             meter
-#&gt; 48          NULL                 1852                             meter
+#&gt; 47          &lt;NA&gt;               1.8288                             meter
+#&gt; 48          &lt;NA&gt;                 1852                             meter
 #&gt; 49          yard               0.9144                             meter
-#&gt; 50          NULL 0.914398530744440774                             meter
-#&gt; 51          NULL         0.2011661949                             meter
-#&gt; 52          NULL  0.91439841461602867                             meter
+#&gt; 50          &lt;NA&gt; 0.914398530744440774                             meter
+#&gt; 51          &lt;NA&gt;         0.2011661949                             meter
+#&gt; 52          &lt;NA&gt;  0.91439841461602867                             meter
 #&gt; 53          mile             1609.344                             meter
 #&gt; 54          nsec          0.000000001                            second
 #&gt; 55          μsec             0.000001                            second
@@ -832,52 +835,52 @@ when defining metadata, e.g. in the table passed to `set_attributes()`.</p>
 #&gt; 71             b             0.035239                             liter
 #&gt; 72           in³       0.000016387064                             liter
 #&gt; 73          pint             0.473176                             liter
-#&gt; 74           rad                    1                              NULL
+#&gt; 74           rad                    1                              &lt;NA&gt;
 #&gt; 75             º         0.0174532924                            radian
 #&gt; 76          grad             0.015707                            radian
 #&gt; 77           MHz              1000000                             hertz
 #&gt; 78           KHz                 1000                             hertz
-#&gt; 79            Hz                    1                              NULL
+#&gt; 79            Hz                    1                              &lt;NA&gt;
 #&gt; 80           mHz             0.000001                             hertz
-#&gt; 81             N                    1                              NULL
-#&gt; 82             J                    1                              NULL
+#&gt; 81             N                    1                              &lt;NA&gt;
+#&gt; 82             J                    1                              &lt;NA&gt;
 #&gt; 83           cal               4.1868                             joule
 #&gt; 84           btu            1055.0559                             joule
-#&gt; 85          NULL             1.355818                             joule
-#&gt; 86            lm                    1                              NULL
-#&gt; 87            lx                    1                              NULL
-#&gt; 88            Bq                    1                              NULL
-#&gt; 89            Gy                    1                              NULL
-#&gt; 90            Sv                    1                              NULL
-#&gt; 91           kat                    1                              NULL
-#&gt; 92             H                    1                              NULL
+#&gt; 85          &lt;NA&gt;             1.355818                             joule
+#&gt; 86            lm                    1                              &lt;NA&gt;
+#&gt; 87            lx                    1                              &lt;NA&gt;
+#&gt; 88            Bq                    1                              &lt;NA&gt;
+#&gt; 89            Gy                    1                              &lt;NA&gt;
+#&gt; 90            Sv                    1                              &lt;NA&gt;
+#&gt; 91           kat                    1                              &lt;NA&gt;
+#&gt; 92             H                    1                              &lt;NA&gt;
 #&gt; 93            MW              1000000                              watt
 #&gt; 94            kW                 1000                              watt
-#&gt; 95             W                    1                              NULL
+#&gt; 95             W                    1                              &lt;NA&gt;
 #&gt; 96            mW                0.001                              watt
 #&gt; 97            MV              1000000                              volt
 #&gt; 98            kV                 1000                              volt
-#&gt; 99             V                    1                              NULL
+#&gt; 99             V                    1                              &lt;NA&gt;
 #&gt; 100           mV                0.001                              volt
-#&gt; 101            F                    1                              NULL
-#&gt; 102            Ω                    1                              NULL
-#&gt; 103           Ωm                    1                              NULL
-#&gt; 104            S                    1                              NULL
-#&gt; 105           Wb                    1                              NULL
-#&gt; 106            T                    1                              NULL
-#&gt; 107           Pa                    1                              NULL
+#&gt; 101            F                    1                              &lt;NA&gt;
+#&gt; 102            Ω                    1                              &lt;NA&gt;
+#&gt; 103           Ωm                    1                              &lt;NA&gt;
+#&gt; 104            S                    1                              &lt;NA&gt;
+#&gt; 105           Wb                    1                              &lt;NA&gt;
+#&gt; 106            T                    1                              &lt;NA&gt;
+#&gt; 107           Pa                    1                              &lt;NA&gt;
 #&gt; 108          MPa              1000000                            pascal
 #&gt; 109          kPa                 1000                            pascal
 #&gt; 110          atm               101325                            pascal
 #&gt; 111          bar               100000                            pascal
 #&gt; 112         mbar                  100                            pascal
-#&gt; 113        kg/m²                    1                              NULL
+#&gt; 113        kg/m²                    1                              &lt;NA&gt;
 #&gt; 114         g/m²                0.001           kilogramsPerSquareMeter
 #&gt; 115        mg/m²             0.000001           kilogramsPerSquareMeter
-#&gt; 116         NULL               0.0001           kilogramsPerSquareMeter
-#&gt; 117         NULL                  0.1           kilogramsPerSquareMeter
+#&gt; 116         &lt;NA&gt;               0.0001           kilogramsPerSquareMeter
+#&gt; 117         &lt;NA&gt;                  0.1           kilogramsPerSquareMeter
 #&gt; 118      lbs/in²                17.85           kilogramsPerSquareMeter
-#&gt; 119         NULL                    1                              NULL
+#&gt; 119         &lt;NA&gt;                    1                              &lt;NA&gt;
 #&gt; 120        kg/m³                    1            kilogramsPerCubicMeter
 #&gt; 121          g/l                    1            kilogramsPerCubicMeter
 #&gt; 122        mg/m³             0.000001            kilogramsPerCubicMeter
@@ -885,26 +888,26 @@ when defining metadata, e.g. in the table passed to `set_attributes()`.</p>
 #&gt; 124         mg/l                0.001            kilogramsPerCubicMeter
 #&gt; 125        g/cm³                 1000            kilogramsPerCubicMeter
 #&gt; 126         g/ml                 1000            kilogramsPerCubicMeter
-#&gt; 127         NULL                    1                              NULL
-#&gt; 128          l/s                    1                              NULL
+#&gt; 127         &lt;NA&gt;                    1                              &lt;NA&gt;
+#&gt; 128          l/s                    1                              &lt;NA&gt;
 #&gt; 129         m³/s                    1                   litersPerSecond
 #&gt; 130      ft³/sec            28.316874                   litersPerSecond
-#&gt; 131           m²                    1                              NULL
+#&gt; 131           m²                    1                              &lt;NA&gt;
 #&gt; 132            a                  100                       squareMeter
 #&gt; 133           ha                10000                       squareMeter
-#&gt; 134         NULL              1000000                       squareMeter
-#&gt; 135         NULL             0.000001                       squareMeter
-#&gt; 136         NULL               0.0001                       squareMeter
+#&gt; 134         &lt;NA&gt;              1000000                       squareMeter
+#&gt; 135         &lt;NA&gt;             0.000001                       squareMeter
+#&gt; 136         &lt;NA&gt;               0.0001                       squareMeter
 #&gt; 137            a            4046.8564                       squareMeter
 #&gt; 138          ft²             0.092903                       squareMeter
 #&gt; 139          yd²             0.836131                       squareMeter
 #&gt; 140        mile²        2589998.49806                       squareMeter
-#&gt; 141         l/m²                    1                              NULL
-#&gt; 142         NULL              0.00870              litersPerSquareMeter
-#&gt; 143         NULL               0.0001              litersPerSquareMeter
-#&gt; 144        m²/kg                    1                              NULL
+#&gt; 141         l/m²                    1                              &lt;NA&gt;
+#&gt; 142         &lt;NA&gt;              0.00870              litersPerSquareMeter
+#&gt; 143         &lt;NA&gt;               0.0001              litersPerSquareMeter
+#&gt; 144        m²/kg                    1                              &lt;NA&gt;
 #&gt; 145          m/s                    1                   metersPerSecond
-#&gt; 146        m/day          .0000115741                              NULL
+#&gt; 146        m/day          .0000115741                              &lt;NA&gt;
 #&gt; 147       ft/day        0.00000352778                   metersPerSecond
 #&gt; 148         ft/s               0.3048                   metersPerSecond
 #&gt; 149        ft/hr          0.000084667                   metersPerSecond
@@ -915,241 +918,241 @@ when defining metadata, e.g. in the table passed to `set_attributes()`.</p>
 #&gt; 154         cm/s                 0.01                   metersPerSecond
 #&gt; 155         mm/s                0.001                   metersPerSecond
 #&gt; 156      cm/year    0.000000000317098                   metersPerSecond
-#&gt; 157         NULL             0.514444                   metersPerSecond
+#&gt; 157         &lt;NA&gt;             0.514444                   metersPerSecond
 #&gt; 158        km/hr               0.2778                   metersPerSecond
-#&gt; 159         m/s²                    1                              NULL
-#&gt; 160         NULL                    1                              NULL
-#&gt; 161        m³/kg                    1                              NULL
+#&gt; 159         m/s²                    1                              &lt;NA&gt;
+#&gt; 160         &lt;NA&gt;                    1                              &lt;NA&gt;
+#&gt; 161        m³/kg                    1                              &lt;NA&gt;
 #&gt; 162       μm³/kg    0.000000000000001             cubicMeterPerKilogram
-#&gt; 163         A/m²                    1                              NULL
-#&gt; 164          A/m                    1                              NULL
-#&gt; 165         NULL                    1                              NULL
+#&gt; 163         A/m²                    1                              &lt;NA&gt;
+#&gt; 164          A/m                    1                              &lt;NA&gt;
+#&gt; 165         &lt;NA&gt;                    1                              &lt;NA&gt;
 #&gt; 166            M                 1000                molesPerCubicMeter
-#&gt; 167            m                    1                              NULL
-#&gt; 168        cd/m²                    1                              NULL
-#&gt; 169         m²/s                    1                              NULL
+#&gt; 167            m                    1                              &lt;NA&gt;
+#&gt; 168        cd/m²                    1                              &lt;NA&gt;
+#&gt; 169         m²/s                    1                              &lt;NA&gt;
 #&gt; 170       m²/day                86400            metersSquaredPerSecond
 #&gt; 171      ft²/day          0.000124586            metersSquaredPerSecond
-#&gt; 172         NULL                    1                              NULL
-#&gt; 173         NULL                  0.1 kilogramsPerMeterSquaredPerSecond
-#&gt; 174         NULL   0.0000000000317098 kilogramsPerMeterSquaredPerSecond
-#&gt; 175         NULL   0.0000000000011574 kilogramsPerMeterSquaredPerSecond
-#&gt; 176         NULL             0.000317 kilogramsPerMeterSquaredPerSecond
-#&gt; 177         NULL           0000000317 kilogramsPerMeterSquaredPerSecond
-#&gt; 178         NULL                    1                              NULL
-#&gt; 179         NULL                 1000                  molesPerKilogram
-#&gt; 180         NULL                    1                  molesPerKilogram
-#&gt; 181         NULL                    1                              NULL
-#&gt; 182         NULL             0.000001         molesPerKilogramPerSecond
-#&gt; 183         kg/s                    1                              NULL
-#&gt; 184         NULL            0.0000317                kilogramsPerSecond
+#&gt; 172         &lt;NA&gt;                    1                              &lt;NA&gt;
+#&gt; 173         &lt;NA&gt;                  0.1 kilogramsPerMeterSquaredPerSecond
+#&gt; 174         &lt;NA&gt;   0.0000000000317098 kilogramsPerMeterSquaredPerSecond
+#&gt; 175         &lt;NA&gt;   0.0000000000011574 kilogramsPerMeterSquaredPerSecond
+#&gt; 176         &lt;NA&gt;             0.000317 kilogramsPerMeterSquaredPerSecond
+#&gt; 177         &lt;NA&gt;           0000000317 kilogramsPerMeterSquaredPerSecond
+#&gt; 178         &lt;NA&gt;                    1                              &lt;NA&gt;
+#&gt; 179         &lt;NA&gt;                 1000                  molesPerKilogram
+#&gt; 180         &lt;NA&gt;                    1                  molesPerKilogram
+#&gt; 181         &lt;NA&gt;                    1                              &lt;NA&gt;
+#&gt; 182         &lt;NA&gt;             0.000001         molesPerKilogramPerSecond
+#&gt; 183         kg/s                    1                              &lt;NA&gt;
+#&gt; 184         &lt;NA&gt;            0.0000317                kilogramsPerSecond
 #&gt; 185         g/yr      0.0000000000317                kilogramsPerSecond
-#&gt; 186         NULL                    1                              NULL
-#&gt; 187         NULL             0.000001             numberPerMeterSquared
-#&gt; 188         NULL                    1                              NULL
-#&gt; 189         NULL                0.001               numberPerMeterCubed
-#&gt; 190         NULL             0.000001               numberPerMeterCubed
-#&gt; 191          m/g                    1                              NULL
-#&gt; 192         NULL                    1                              NULL
-#&gt; 193         NULL                    1                              NULL
-#&gt; 194         NULL             0.000001                      gramsPerGram
-#&gt; 195         NULL                    1                              NULL
+#&gt; 186         &lt;NA&gt;                    1                              &lt;NA&gt;
+#&gt; 187         &lt;NA&gt;             0.000001             numberPerMeterSquared
+#&gt; 188         &lt;NA&gt;                    1                              &lt;NA&gt;
+#&gt; 189         &lt;NA&gt;                0.001               numberPerMeterCubed
+#&gt; 190         &lt;NA&gt;             0.000001               numberPerMeterCubed
+#&gt; 191          m/g                    1                              &lt;NA&gt;
+#&gt; 192         &lt;NA&gt;                    1                              &lt;NA&gt;
+#&gt; 193         &lt;NA&gt;                    1                              &lt;NA&gt;
+#&gt; 194         &lt;NA&gt;             0.000001                      gramsPerGram
+#&gt; 195         &lt;NA&gt;                    1                              &lt;NA&gt;
 #&gt;     constantToSI
-#&gt; 1           NULL
-#&gt; 2           NULL
-#&gt; 3           NULL
-#&gt; 4           NULL
-#&gt; 5           NULL
-#&gt; 6           NULL
-#&gt; 7           NULL
-#&gt; 8           NULL
-#&gt; 9           NULL
-#&gt; 10          NULL
-#&gt; 11          NULL
-#&gt; 12          NULL
-#&gt; 13          NULL
-#&gt; 14          NULL
-#&gt; 15          NULL
-#&gt; 16          NULL
-#&gt; 17          NULL
-#&gt; 18          NULL
-#&gt; 19          NULL
-#&gt; 20          NULL
-#&gt; 21          NULL
-#&gt; 22          NULL
-#&gt; 23          NULL
-#&gt; 24          NULL
-#&gt; 25          NULL
-#&gt; 26          NULL
-#&gt; 27          NULL
-#&gt; 28          NULL
-#&gt; 29          NULL
+#&gt; 1           &lt;NA&gt;
+#&gt; 2           &lt;NA&gt;
+#&gt; 3           &lt;NA&gt;
+#&gt; 4           &lt;NA&gt;
+#&gt; 5           &lt;NA&gt;
+#&gt; 6           &lt;NA&gt;
+#&gt; 7           &lt;NA&gt;
+#&gt; 8           &lt;NA&gt;
+#&gt; 9           &lt;NA&gt;
+#&gt; 10          &lt;NA&gt;
+#&gt; 11          &lt;NA&gt;
+#&gt; 12          &lt;NA&gt;
+#&gt; 13          &lt;NA&gt;
+#&gt; 14          &lt;NA&gt;
+#&gt; 15          &lt;NA&gt;
+#&gt; 16          &lt;NA&gt;
+#&gt; 17          &lt;NA&gt;
+#&gt; 18          &lt;NA&gt;
+#&gt; 19          &lt;NA&gt;
+#&gt; 20          &lt;NA&gt;
+#&gt; 21          &lt;NA&gt;
+#&gt; 22          &lt;NA&gt;
+#&gt; 23          &lt;NA&gt;
+#&gt; 24          &lt;NA&gt;
+#&gt; 25          &lt;NA&gt;
+#&gt; 26          &lt;NA&gt;
+#&gt; 27          &lt;NA&gt;
+#&gt; 28          &lt;NA&gt;
+#&gt; 29          &lt;NA&gt;
 #&gt; 30        273.18
 #&gt; 31       255.402
-#&gt; 32          NULL
-#&gt; 33          NULL
-#&gt; 34          NULL
-#&gt; 35          NULL
-#&gt; 36          NULL
-#&gt; 37          NULL
-#&gt; 38          NULL
-#&gt; 39          NULL
-#&gt; 40          NULL
-#&gt; 41          NULL
-#&gt; 42          NULL
-#&gt; 43          NULL
-#&gt; 44          NULL
-#&gt; 45          NULL
-#&gt; 46          NULL
-#&gt; 47          NULL
-#&gt; 48          NULL
-#&gt; 49          NULL
-#&gt; 50          NULL
-#&gt; 51          NULL
-#&gt; 52          NULL
-#&gt; 53          NULL
-#&gt; 54          NULL
-#&gt; 55          NULL
-#&gt; 56          NULL
-#&gt; 57          NULL
-#&gt; 58          NULL
-#&gt; 59          NULL
-#&gt; 60          NULL
-#&gt; 61          NULL
-#&gt; 62          NULL
-#&gt; 63          NULL
-#&gt; 64          NULL
-#&gt; 65          NULL
-#&gt; 66          NULL
-#&gt; 67          NULL
-#&gt; 68          NULL
-#&gt; 69          NULL
-#&gt; 70          NULL
-#&gt; 71          NULL
-#&gt; 72          NULL
-#&gt; 73          NULL
-#&gt; 74          NULL
-#&gt; 75          NULL
-#&gt; 76          NULL
-#&gt; 77          NULL
-#&gt; 78          NULL
-#&gt; 79          NULL
-#&gt; 80          NULL
-#&gt; 81          NULL
-#&gt; 82          NULL
-#&gt; 83          NULL
-#&gt; 84          NULL
-#&gt; 85          NULL
-#&gt; 86          NULL
-#&gt; 87          NULL
-#&gt; 88          NULL
-#&gt; 89          NULL
-#&gt; 90          NULL
-#&gt; 91          NULL
-#&gt; 92          NULL
-#&gt; 93          NULL
-#&gt; 94          NULL
-#&gt; 95          NULL
-#&gt; 96          NULL
-#&gt; 97          NULL
-#&gt; 98          NULL
-#&gt; 99          NULL
-#&gt; 100         NULL
-#&gt; 101         NULL
-#&gt; 102         NULL
-#&gt; 103         NULL
-#&gt; 104         NULL
-#&gt; 105         NULL
-#&gt; 106         NULL
-#&gt; 107         NULL
-#&gt; 108         NULL
-#&gt; 109         NULL
-#&gt; 110         NULL
-#&gt; 111         NULL
-#&gt; 112         NULL
-#&gt; 113         NULL
-#&gt; 114         NULL
-#&gt; 115         NULL
-#&gt; 116         NULL
-#&gt; 117         NULL
-#&gt; 118         NULL
-#&gt; 119         NULL
-#&gt; 120         NULL
-#&gt; 121         NULL
-#&gt; 122         NULL
-#&gt; 123         NULL
-#&gt; 124         NULL
-#&gt; 125         NULL
-#&gt; 126         NULL
-#&gt; 127         NULL
-#&gt; 128         NULL
-#&gt; 129         NULL
-#&gt; 130         NULL
-#&gt; 131         NULL
-#&gt; 132         NULL
-#&gt; 133         NULL
-#&gt; 134         NULL
-#&gt; 135         NULL
-#&gt; 136         NULL
-#&gt; 137         NULL
-#&gt; 138         NULL
-#&gt; 139         NULL
-#&gt; 140         NULL
-#&gt; 141         NULL
-#&gt; 142         NULL
-#&gt; 143         NULL
-#&gt; 144         NULL
-#&gt; 145         NULL
-#&gt; 146         NULL
-#&gt; 147         NULL
-#&gt; 148         NULL
-#&gt; 149         NULL
-#&gt; 150         NULL
-#&gt; 151         NULL
-#&gt; 152         NULL
-#&gt; 153         NULL
-#&gt; 154         NULL
-#&gt; 155         NULL
-#&gt; 156         NULL
-#&gt; 157         NULL
-#&gt; 158         NULL
-#&gt; 159         NULL
-#&gt; 160         NULL
-#&gt; 161         NULL
-#&gt; 162         NULL
-#&gt; 163         NULL
-#&gt; 164         NULL
-#&gt; 165         NULL
-#&gt; 166         NULL
-#&gt; 167         NULL
-#&gt; 168         NULL
-#&gt; 169         NULL
-#&gt; 170         NULL
-#&gt; 171         NULL
-#&gt; 172         NULL
-#&gt; 173         NULL
-#&gt; 174         NULL
-#&gt; 175         NULL
-#&gt; 176         NULL
-#&gt; 177         NULL
-#&gt; 178         NULL
-#&gt; 179         NULL
-#&gt; 180         NULL
-#&gt; 181         NULL
-#&gt; 182         NULL
-#&gt; 183         NULL
-#&gt; 184         NULL
-#&gt; 185         NULL
-#&gt; 186         NULL
-#&gt; 187         NULL
-#&gt; 188         NULL
-#&gt; 189         NULL
-#&gt; 190         NULL
-#&gt; 191         NULL
-#&gt; 192         NULL
-#&gt; 193         NULL
-#&gt; 194         NULL
-#&gt; 195         NULL
+#&gt; 32          &lt;NA&gt;
+#&gt; 33          &lt;NA&gt;
+#&gt; 34          &lt;NA&gt;
+#&gt; 35          &lt;NA&gt;
+#&gt; 36          &lt;NA&gt;
+#&gt; 37          &lt;NA&gt;
+#&gt; 38          &lt;NA&gt;
+#&gt; 39          &lt;NA&gt;
+#&gt; 40          &lt;NA&gt;
+#&gt; 41          &lt;NA&gt;
+#&gt; 42          &lt;NA&gt;
+#&gt; 43          &lt;NA&gt;
+#&gt; 44          &lt;NA&gt;
+#&gt; 45          &lt;NA&gt;
+#&gt; 46          &lt;NA&gt;
+#&gt; 47          &lt;NA&gt;
+#&gt; 48          &lt;NA&gt;
+#&gt; 49          &lt;NA&gt;
+#&gt; 50          &lt;NA&gt;
+#&gt; 51          &lt;NA&gt;
+#&gt; 52          &lt;NA&gt;
+#&gt; 53          &lt;NA&gt;
+#&gt; 54          &lt;NA&gt;
+#&gt; 55          &lt;NA&gt;
+#&gt; 56          &lt;NA&gt;
+#&gt; 57          &lt;NA&gt;
+#&gt; 58          &lt;NA&gt;
+#&gt; 59          &lt;NA&gt;
+#&gt; 60          &lt;NA&gt;
+#&gt; 61          &lt;NA&gt;
+#&gt; 62          &lt;NA&gt;
+#&gt; 63          &lt;NA&gt;
+#&gt; 64          &lt;NA&gt;
+#&gt; 65          &lt;NA&gt;
+#&gt; 66          &lt;NA&gt;
+#&gt; 67          &lt;NA&gt;
+#&gt; 68          &lt;NA&gt;
+#&gt; 69          &lt;NA&gt;
+#&gt; 70          &lt;NA&gt;
+#&gt; 71          &lt;NA&gt;
+#&gt; 72          &lt;NA&gt;
+#&gt; 73          &lt;NA&gt;
+#&gt; 74          &lt;NA&gt;
+#&gt; 75          &lt;NA&gt;
+#&gt; 76          &lt;NA&gt;
+#&gt; 77          &lt;NA&gt;
+#&gt; 78          &lt;NA&gt;
+#&gt; 79          &lt;NA&gt;
+#&gt; 80          &lt;NA&gt;
+#&gt; 81          &lt;NA&gt;
+#&gt; 82          &lt;NA&gt;
+#&gt; 83          &lt;NA&gt;
+#&gt; 84          &lt;NA&gt;
+#&gt; 85          &lt;NA&gt;
+#&gt; 86          &lt;NA&gt;
+#&gt; 87          &lt;NA&gt;
+#&gt; 88          &lt;NA&gt;
+#&gt; 89          &lt;NA&gt;
+#&gt; 90          &lt;NA&gt;
+#&gt; 91          &lt;NA&gt;
+#&gt; 92          &lt;NA&gt;
+#&gt; 93          &lt;NA&gt;
+#&gt; 94          &lt;NA&gt;
+#&gt; 95          &lt;NA&gt;
+#&gt; 96          &lt;NA&gt;
+#&gt; 97          &lt;NA&gt;
+#&gt; 98          &lt;NA&gt;
+#&gt; 99          &lt;NA&gt;
+#&gt; 100         &lt;NA&gt;
+#&gt; 101         &lt;NA&gt;
+#&gt; 102         &lt;NA&gt;
+#&gt; 103         &lt;NA&gt;
+#&gt; 104         &lt;NA&gt;
+#&gt; 105         &lt;NA&gt;
+#&gt; 106         &lt;NA&gt;
+#&gt; 107         &lt;NA&gt;
+#&gt; 108         &lt;NA&gt;
+#&gt; 109         &lt;NA&gt;
+#&gt; 110         &lt;NA&gt;
+#&gt; 111         &lt;NA&gt;
+#&gt; 112         &lt;NA&gt;
+#&gt; 113         &lt;NA&gt;
+#&gt; 114         &lt;NA&gt;
+#&gt; 115         &lt;NA&gt;
+#&gt; 116         &lt;NA&gt;
+#&gt; 117         &lt;NA&gt;
+#&gt; 118         &lt;NA&gt;
+#&gt; 119         &lt;NA&gt;
+#&gt; 120         &lt;NA&gt;
+#&gt; 121         &lt;NA&gt;
+#&gt; 122         &lt;NA&gt;
+#&gt; 123         &lt;NA&gt;
+#&gt; 124         &lt;NA&gt;
+#&gt; 125         &lt;NA&gt;
+#&gt; 126         &lt;NA&gt;
+#&gt; 127         &lt;NA&gt;
+#&gt; 128         &lt;NA&gt;
+#&gt; 129         &lt;NA&gt;
+#&gt; 130         &lt;NA&gt;
+#&gt; 131         &lt;NA&gt;
+#&gt; 132         &lt;NA&gt;
+#&gt; 133         &lt;NA&gt;
+#&gt; 134         &lt;NA&gt;
+#&gt; 135         &lt;NA&gt;
+#&gt; 136         &lt;NA&gt;
+#&gt; 137         &lt;NA&gt;
+#&gt; 138         &lt;NA&gt;
+#&gt; 139         &lt;NA&gt;
+#&gt; 140         &lt;NA&gt;
+#&gt; 141         &lt;NA&gt;
+#&gt; 142         &lt;NA&gt;
+#&gt; 143         &lt;NA&gt;
+#&gt; 144         &lt;NA&gt;
+#&gt; 145         &lt;NA&gt;
+#&gt; 146         &lt;NA&gt;
+#&gt; 147         &lt;NA&gt;
+#&gt; 148         &lt;NA&gt;
+#&gt; 149         &lt;NA&gt;
+#&gt; 150         &lt;NA&gt;
+#&gt; 151         &lt;NA&gt;
+#&gt; 152         &lt;NA&gt;
+#&gt; 153         &lt;NA&gt;
+#&gt; 154         &lt;NA&gt;
+#&gt; 155         &lt;NA&gt;
+#&gt; 156         &lt;NA&gt;
+#&gt; 157         &lt;NA&gt;
+#&gt; 158         &lt;NA&gt;
+#&gt; 159         &lt;NA&gt;
+#&gt; 160         &lt;NA&gt;
+#&gt; 161         &lt;NA&gt;
+#&gt; 162         &lt;NA&gt;
+#&gt; 163         &lt;NA&gt;
+#&gt; 164         &lt;NA&gt;
+#&gt; 165         &lt;NA&gt;
+#&gt; 166         &lt;NA&gt;
+#&gt; 167         &lt;NA&gt;
+#&gt; 168         &lt;NA&gt;
+#&gt; 169         &lt;NA&gt;
+#&gt; 170         &lt;NA&gt;
+#&gt; 171         &lt;NA&gt;
+#&gt; 172         &lt;NA&gt;
+#&gt; 173         &lt;NA&gt;
+#&gt; 174         &lt;NA&gt;
+#&gt; 175         &lt;NA&gt;
+#&gt; 176         &lt;NA&gt;
+#&gt; 177         &lt;NA&gt;
+#&gt; 178         &lt;NA&gt;
+#&gt; 179         &lt;NA&gt;
+#&gt; 180         &lt;NA&gt;
+#&gt; 181         &lt;NA&gt;
+#&gt; 182         &lt;NA&gt;
+#&gt; 183         &lt;NA&gt;
+#&gt; 184         &lt;NA&gt;
+#&gt; 185         &lt;NA&gt;
+#&gt; 186         &lt;NA&gt;
+#&gt; 187         &lt;NA&gt;
+#&gt; 188         &lt;NA&gt;
+#&gt; 189         &lt;NA&gt;
+#&gt; 190         &lt;NA&gt;
+#&gt; 191         &lt;NA&gt;
+#&gt; 192         &lt;NA&gt;
+#&gt; 193         &lt;NA&gt;
+#&gt; 194         &lt;NA&gt;
+#&gt; 195         &lt;NA&gt;
 #&gt; 
 #&gt; $unitTypes
 #&gt;                                 id                           name     dimension
@@ -1442,37 +1445,37 @@ when defining metadata, e.g. in the table passed to `set_attributes()`.</p>
 #&gt; 287              massSpecificCount              massSpecificCount          mass
 #&gt; 288              massSpecificCount              massSpecificCount          mass
 #&gt;     power
-#&gt; 1    NULL
+#&gt; 1    &lt;NA&gt;
 #&gt; 2      -2
-#&gt; 3    NULL
+#&gt; 3    &lt;NA&gt;
 #&gt; 4      -2
-#&gt; 5    NULL
+#&gt; 5    &lt;NA&gt;
 #&gt; 6       1
-#&gt; 7    NULL
+#&gt; 7    &lt;NA&gt;
 #&gt; 8       1
-#&gt; 9    NULL
+#&gt; 9    &lt;NA&gt;
 #&gt; 10     -1
-#&gt; 11   NULL
+#&gt; 11   &lt;NA&gt;
 #&gt; 12     -1
-#&gt; 13   NULL
+#&gt; 13   &lt;NA&gt;
 #&gt; 14     -2
-#&gt; 15   NULL
+#&gt; 15   &lt;NA&gt;
 #&gt; 16     -2
 #&gt; 17      3
 #&gt; 18     -2
 #&gt; 19      3
 #&gt; 20     -2
-#&gt; 21   NULL
+#&gt; 21   &lt;NA&gt;
 #&gt; 22     -1
-#&gt; 23   NULL
+#&gt; 23   &lt;NA&gt;
 #&gt; 24     -1
-#&gt; 25   NULL
+#&gt; 25   &lt;NA&gt;
 #&gt; 26     -3
-#&gt; 27   NULL
+#&gt; 27   &lt;NA&gt;
 #&gt; 28     -3
-#&gt; 29   NULL
+#&gt; 29   &lt;NA&gt;
 #&gt; 30     -1
-#&gt; 31   NULL
+#&gt; 31   &lt;NA&gt;
 #&gt; 32     -1
 #&gt; 33      3
 #&gt; 34     -3
@@ -1482,109 +1485,109 @@ when defining metadata, e.g. in the table passed to `set_attributes()`.</p>
 #&gt; 38     -1
 #&gt; 39      3
 #&gt; 40     -1
-#&gt; 41   NULL
+#&gt; 41   &lt;NA&gt;
 #&gt; 42     -3
 #&gt; 43     -1
-#&gt; 44   NULL
+#&gt; 44   &lt;NA&gt;
 #&gt; 45     -3
 #&gt; 46     -1
-#&gt; 47   NULL
+#&gt; 47   &lt;NA&gt;
 #&gt; 48     -3
 #&gt; 49     -1
-#&gt; 50   NULL
+#&gt; 50   &lt;NA&gt;
 #&gt; 51     -2
 #&gt; 52     -1
-#&gt; 53   NULL
+#&gt; 53   &lt;NA&gt;
 #&gt; 54     -2
 #&gt; 55     -1
-#&gt; 56   NULL
+#&gt; 56   &lt;NA&gt;
 #&gt; 57     -2
 #&gt; 58     -1
 #&gt; 59     -1
 #&gt; 60      3
 #&gt; 61     -1
 #&gt; 62      3
-#&gt; 63   NULL
+#&gt; 63   &lt;NA&gt;
 #&gt; 64     -3
-#&gt; 65   NULL
+#&gt; 65   &lt;NA&gt;
 #&gt; 66     -3
-#&gt; 67   NULL
+#&gt; 67   &lt;NA&gt;
 #&gt; 68     -1
-#&gt; 69   NULL
+#&gt; 69   &lt;NA&gt;
 #&gt; 70     -1
-#&gt; 71   NULL
+#&gt; 71   &lt;NA&gt;
 #&gt; 72     -1
 #&gt; 73     -1
-#&gt; 74   NULL
+#&gt; 74   &lt;NA&gt;
 #&gt; 75     -1
 #&gt; 76     -1
-#&gt; 77   NULL
+#&gt; 77   &lt;NA&gt;
 #&gt; 78     -1
 #&gt; 79     -1
-#&gt; 80   NULL
+#&gt; 80   &lt;NA&gt;
 #&gt; 81     -1
-#&gt; 82   NULL
+#&gt; 82   &lt;NA&gt;
 #&gt; 83     -1
-#&gt; 84   NULL
+#&gt; 84   &lt;NA&gt;
 #&gt; 85     -2
-#&gt; 86   NULL
+#&gt; 86   &lt;NA&gt;
 #&gt; 87     -2
-#&gt; 88   NULL
+#&gt; 88   &lt;NA&gt;
 #&gt; 89     -3
-#&gt; 90   NULL
+#&gt; 90   &lt;NA&gt;
 #&gt; 91     -3
-#&gt; 92   NULL
+#&gt; 92   &lt;NA&gt;
 #&gt; 93     -2
-#&gt; 94   NULL
+#&gt; 94   &lt;NA&gt;
 #&gt; 95     -2
-#&gt; 96   NULL
+#&gt; 96   &lt;NA&gt;
 #&gt; 97     -2
-#&gt; 98   NULL
+#&gt; 98   &lt;NA&gt;
 #&gt; 99     -2
 #&gt; 100    -1
 #&gt; 101     2
 #&gt; 102    -1
 #&gt; 103     2
-#&gt; 104  NULL
-#&gt; 105  NULL
+#&gt; 104  &lt;NA&gt;
+#&gt; 105  &lt;NA&gt;
 #&gt; 106    -2
-#&gt; 107  NULL
-#&gt; 108  NULL
+#&gt; 107  &lt;NA&gt;
+#&gt; 108  &lt;NA&gt;
 #&gt; 109    -2
-#&gt; 110  NULL
-#&gt; 111  NULL
+#&gt; 110  &lt;NA&gt;
+#&gt; 111  &lt;NA&gt;
 #&gt; 112    -2
-#&gt; 113  NULL
+#&gt; 113  &lt;NA&gt;
 #&gt; 114     2
 #&gt; 115    -2
-#&gt; 116  NULL
+#&gt; 116  &lt;NA&gt;
 #&gt; 117     2
 #&gt; 118    -2
-#&gt; 119  NULL
+#&gt; 119  &lt;NA&gt;
 #&gt; 120     2
 #&gt; 121    -2
-#&gt; 122  NULL
+#&gt; 122  &lt;NA&gt;
 #&gt; 123     2
 #&gt; 124    -3
-#&gt; 125  NULL
+#&gt; 125  &lt;NA&gt;
 #&gt; 126     2
 #&gt; 127    -3
-#&gt; 128  NULL
+#&gt; 128  &lt;NA&gt;
 #&gt; 129     2
 #&gt; 130    -3
-#&gt; 131  NULL
+#&gt; 131  &lt;NA&gt;
 #&gt; 132     2
 #&gt; 133    -3
 #&gt; 134    -1
-#&gt; 135  NULL
+#&gt; 135  &lt;NA&gt;
 #&gt; 136     2
 #&gt; 137    -3
 #&gt; 138    -1
-#&gt; 139  NULL
+#&gt; 139  &lt;NA&gt;
 #&gt; 140     2
 #&gt; 141    -3
 #&gt; 142    -1
-#&gt; 143  NULL
+#&gt; 143  &lt;NA&gt;
 #&gt; 144     2
 #&gt; 145    -3
 #&gt; 146    -1
@@ -1604,35 +1607,35 @@ when defining metadata, e.g. in the table passed to `set_attributes()`.</p>
 #&gt; 160    -2
 #&gt; 161     4
 #&gt; 162     2
-#&gt; 163  NULL
+#&gt; 163  &lt;NA&gt;
 #&gt; 164     2
 #&gt; 165    -3
 #&gt; 166    -2
-#&gt; 167  NULL
+#&gt; 167  &lt;NA&gt;
 #&gt; 168     2
 #&gt; 169    -3
 #&gt; 170    -2
-#&gt; 171  NULL
+#&gt; 171  &lt;NA&gt;
 #&gt; 172     2
 #&gt; 173    -3
 #&gt; 174    -2
-#&gt; 175  NULL
+#&gt; 175  &lt;NA&gt;
 #&gt; 176     2
 #&gt; 177    -3
 #&gt; 178    -2
-#&gt; 179  NULL
+#&gt; 179  &lt;NA&gt;
 #&gt; 180     3
 #&gt; 181    -3
 #&gt; 182    -2
-#&gt; 183  NULL
+#&gt; 183  &lt;NA&gt;
 #&gt; 184     3
 #&gt; 185    -3
 #&gt; 186    -2
-#&gt; 187  NULL
+#&gt; 187  &lt;NA&gt;
 #&gt; 188     3
 #&gt; 189    -3
 #&gt; 190    -2
-#&gt; 191  NULL
+#&gt; 191  &lt;NA&gt;
 #&gt; 192     3
 #&gt; 193    -3
 #&gt; 194    -2
@@ -1652,50 +1655,50 @@ when defining metadata, e.g. in the table passed to `set_attributes()`.</p>
 #&gt; 208    -2
 #&gt; 209     3
 #&gt; 210     2
-#&gt; 211  NULL
+#&gt; 211  &lt;NA&gt;
 #&gt; 212     2
 #&gt; 213    -2
 #&gt; 214    -1
-#&gt; 215  NULL
+#&gt; 215  &lt;NA&gt;
 #&gt; 216     2
 #&gt; 217    -2
 #&gt; 218    -1
-#&gt; 219  NULL
+#&gt; 219  &lt;NA&gt;
 #&gt; 220     2
 #&gt; 221    -2
 #&gt; 222    -1
-#&gt; 223  NULL
+#&gt; 223  &lt;NA&gt;
 #&gt; 224     2
 #&gt; 225    -2
 #&gt; 226    -1
-#&gt; 227  NULL
+#&gt; 227  &lt;NA&gt;
 #&gt; 228    -2
 #&gt; 229    -1
-#&gt; 230  NULL
+#&gt; 230  &lt;NA&gt;
 #&gt; 231    -2
 #&gt; 232    -1
-#&gt; 233  NULL
+#&gt; 233  &lt;NA&gt;
 #&gt; 234    -2
 #&gt; 235    -1
-#&gt; 236  NULL
+#&gt; 236  &lt;NA&gt;
 #&gt; 237     2
 #&gt; 238    -2
 #&gt; 239    -2
-#&gt; 240  NULL
+#&gt; 240  &lt;NA&gt;
 #&gt; 241     2
 #&gt; 242    -2
 #&gt; 243    -2
-#&gt; 244  NULL
+#&gt; 244  &lt;NA&gt;
 #&gt; 245     2
 #&gt; 246    -2
 #&gt; 247    -2
-#&gt; 248  NULL
+#&gt; 248  &lt;NA&gt;
 #&gt; 249     2
 #&gt; 250    -2
 #&gt; 251    -2
-#&gt; 252  NULL
+#&gt; 252  &lt;NA&gt;
 #&gt; 253    -2
-#&gt; 254  NULL
+#&gt; 254  &lt;NA&gt;
 #&gt; 255    -2
 #&gt; 256    -2
 #&gt; 257     2
@@ -1706,29 +1709,29 @@ when defining metadata, e.g. in the table passed to `set_attributes()`.</p>
 #&gt; 262    -2
 #&gt; 263     2
 #&gt; 264    -1
-#&gt; 265  NULL
+#&gt; 265  &lt;NA&gt;
 #&gt; 266    -1
-#&gt; 267  NULL
-#&gt; 268  NULL
+#&gt; 267  &lt;NA&gt;
+#&gt; 268  &lt;NA&gt;
 #&gt; 269    -2
 #&gt; 270     1
-#&gt; 271  NULL
+#&gt; 271  &lt;NA&gt;
 #&gt; 272    -2
 #&gt; 273     1
-#&gt; 274  NULL
+#&gt; 274  &lt;NA&gt;
 #&gt; 275    -2
 #&gt; 276     1
 #&gt; 277     2
 #&gt; 278    -1
 #&gt; 279     2
 #&gt; 280    -1
-#&gt; 281  NULL
+#&gt; 281  &lt;NA&gt;
 #&gt; 282    -1
-#&gt; 283  NULL
+#&gt; 283  &lt;NA&gt;
 #&gt; 284    -1
-#&gt; 285  NULL
+#&gt; 285  &lt;NA&gt;
 #&gt; 286    -1
-#&gt; 287  NULL
+#&gt; 287  &lt;NA&gt;
 #&gt; 288    -1
 #&gt; </div><div class='input'>
 </div></pre>
@@ -1754,7 +1757,7 @@ when defining metadata, e.g. in the table passed to `set_attributes()`.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/get_unit_id.html
+++ b/docs/reference/get_unit_id.html
@@ -75,7 +75,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -104,6 +104,9 @@
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -140,7 +143,7 @@
     
     </div>
 
-    <pre class="usage"><span class='fu'>get_unit_id</span>(<span class='no'>input_units</span>, <span class='kw'>eml_version</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/options'>getOption</a></span>(<span class='st'>"emld_db"</span>, <span class='st'>"eml-2.2.0"</span>))</pre>
+    <pre class="usage"><span class='fu'>get_unit_id</span>(<span class='no'>input_units</span>, <span class='kw'>eml_version</span> <span class='kw'>=</span> <span class='kw pkg'>emld</span><span class='kw ns'>::</span><span class='fu'><a href='https://www.rdocumentation.org/packages/emld/topics/eml_version'>eml_version</a></span>())</pre>
     
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -195,7 +198,7 @@ valid EML unit ids</p></td>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/htmlwidgets_attributes.html
+++ b/docs/reference/htmlwidgets_attributes.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -101,6 +101,9 @@
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -166,7 +169,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -70,7 +70,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -99,6 +99,9 @@
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -308,7 +311,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/is_standardUnit.html
+++ b/docs/reference/is_standardUnit.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -101,6 +101,9 @@
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -173,7 +176,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/read_eml.html
+++ b/docs/reference/read_eml.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -101,6 +101,9 @@
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -178,7 +181,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/reexports.html
+++ b/docs/reference/reexports.html
@@ -76,7 +76,7 @@ below to see their documentation.
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -105,6 +105,9 @@ below to see their documentation.
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -159,7 +162,7 @@ below to see their documentation.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/set_TextType.html
+++ b/docs/reference/set_TextType.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -101,6 +101,9 @@
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -202,7 +205,7 @@ required for the rmarkdown package.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/set_attributes.html
+++ b/docs/reference/set_attributes.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -101,6 +101,9 @@
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -134,7 +137,8 @@
     
     </div>
 
-    <pre class="usage"><span class='fu'>set_attributes</span>(<span class='no'>attributes</span>, <span class='kw'>factors</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>col_classes</span> <span class='kw'>=</span> <span class='kw'>NULL</span>)</pre>
+    <pre class="usage"><span class='fu'>set_attributes</span>(<span class='no'>attributes</span>, <span class='kw'>factors</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>col_classes</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
+  <span class='kw'>missingValues</span> <span class='kw'>=</span> <span class='kw'>NULL</span>)</pre>
     
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -154,6 +158,10 @@ will let the function infer missing 'domain' and 'measurementScale' values for a
 Should be in same order as attributeNames in the attributes table, or be a named list with names corresponding to attributeNames
 in the attributes table.</p></td>
     </tr>
+    <tr>
+      <th>missingValues</th>
+      <td><p>optional, a table with missing value code-deinition pairs; see details</p></td>
+    </tr>
     </table>
     
     <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
@@ -165,20 +173,40 @@ in the attributes table.</p></td>
     <p>The attributes data frame must use only the recognized column
 headers shown here.  The attributes data frame must contain columns for required metadata.
 These are:</p>
-<p>For all data:
-- attributeName (required, free text field)
-- attributeDefinition (required, free text field)
-- measurementScale (required, "nominal", "ordinal", "ratio", "interval", or "dateTime",
- case sensitive) but it can be inferred from col_classes.
-- domain (required, "numericDomain", "textDomain", "enumeratedDomain", or "dateTimeDomain",
- case sensitive) but it can be inferred from col_classes.</p>
-<p>For numeric (ratio or interval) data:
-- unit (required)</p>
-<p>For character (textDomain) data:
-- definition (required)</p>
-<p>For dateTime data:
-- formatString (required)</p>
-<p>For factor data:</p>
+<p><strong>For all data:</strong></p>
+<ul>
+<li><p>attributeName (required, free text field)</p></li>
+<li><p>attributeDefinition (required, free text field)</p></li>
+<li><p>measurementScale (required, "nominal", "ordinal", "ratio", "interval", or "dateTime",
+ case sensitive) but it can be inferred from col_classes.</p></li>
+<li><p>domain (required, "numericDomain", "textDomain", "enumeratedDomain", or "dateTimeDomain",
+ case sensitive) but it can be inferred from col_classes.</p></li>
+</ul>
+    <p><strong>For numeric (ratio or interval) data:</strong></p><ul>
+<li><p>unit (required). Unitless values should use "dimensionless" as the unit.</p></li>
+</ul>
+    <p><strong>For character (textDomain) data:</strong></p><ul>
+<li><p>definition (required)</p></li>
+</ul>
+    <p><strong>For dateTime data:</strong></p><ul>
+<li><p>formatString (required)</p></li>
+</ul>
+    <p>Other optional allowed columns in the attributes table are:
+source, pattern, precision, numberType, missingValueCode, missingValueCodeExplanation,
+attributeLabel, storageType, minimum, maximum</p>
+<p>The <strong>factors</strong> data frame, required for attributes in an enumerated domain, must use only the
+ following recognized column headers:</p><ul>
+<li><p>attributeName (required)</p></li>
+<li><p>code (required)</p></li>
+<li><p>definition (required)</p></li>
+</ul>
+    <p>The <strong>missingValues</strong> data frame, optional, can be used in the case that multiple missing value codes
+need to be set for the same attribute. This table must contain the following recognized column
+headers.</p><ul>
+<li><p>attributeName (required)</p></li>
+<li><p>code (required)</p></li>
+<li><p>definition (required)</p></li>
+</ul>
     
 
   </div>
@@ -201,7 +229,7 @@ These are:</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/set_coverage.html
+++ b/docs/reference/set_coverage.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -101,6 +101,9 @@
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -160,7 +163,7 @@
     </tr>
     <tr>
       <th>sci_names</th>
-      <td><p>string (space seperated) or list or data frame of scientific names for species covered.  See details</p></td>
+      <td><p>string (space separated) or list or data frame of scientific names for species covered.  See details</p></td>
     </tr>
     <tr>
       <th>geographicDescription</th>
@@ -249,7 +252,7 @@ Ex. "Kingdom","Phylum","Class","Order","Family","Genus","Species","Common"</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/set_methods.html
+++ b/docs/reference/set_methods.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -101,6 +101,9 @@
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -248,7 +251,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/set_physical.html
+++ b/docs/reference/set_physical.html
@@ -73,7 +73,7 @@ algorithm automatically if the argument objectName is a file that exists." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -102,6 +102,9 @@ algorithm automatically if the argument objectName is a file that exists." />
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -175,7 +178,7 @@ algorithm automatically if the argument <code>objectName</code> is a file that e
     </tr>
     <tr>
       <th>collapseDelimiters</th>
-      <td><p>The collapseDelimiters element specifies whether sequential delimiters should be treated as a single delimiter or multiple delimiters. An example is when a space delimiter is used; often there may be several repeated spaces that should be treated as a single delimiter, but not always. The valid values are yes or no. If it is set to yes, then consecutive delimiters will be collapsed to one. If set to no or absent, then consecutive delimiters will be treated as separate delimiters. Default behaviour is no; hence, consecutive delimiters will be treated as separate delimiters, by default.</p></td>
+      <td><p>The collapseDelimiters element specifies whether sequential delimiters should be treated as a single delimiter or multiple delimiters. An example is when a space delimiter is used; often there may be several repeated spaces that should be treated as a single delimiter, but not always. The valid values are yes or no. If it is set to yes, then consecutive delimiters will be collapsed to one. If set to no or absent, then consecutive delimiters will be treated as separate delimiters. Default behavior is no; hence, consecutive delimiters will be treated as separate delimiters, by default.</p></td>
     </tr>
     <tr>
       <th>literalCharacter</th>
@@ -310,7 +313,7 @@ algorithm automatically if the argument <code>objectName</code> is a file that e
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/set_responsibleParty.html
+++ b/docs/reference/set_responsibleParty.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -101,6 +101,9 @@
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -180,7 +183,7 @@
     </tr>
     <tr>
       <th>id</th>
-      <td><p>Identifier for this plock, ideally an ORCID id (optional)</p></td>
+      <td><p>Identifier for this block, ideally an ORCID id (optional)</p></td>
     </tr>
     <tr>
       <th>email</th>
@@ -216,7 +219,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/set_software.html
+++ b/docs/reference/set_software.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -101,6 +101,9 @@
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -176,7 +179,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/set_taxonomicCoverage.html
+++ b/docs/reference/set_taxonomicCoverage.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -101,6 +101,9 @@
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -141,7 +144,7 @@
     <colgroup><col class="name" /><col class="desc" /></colgroup>
     <tr>
       <th>sci_names</th>
-      <td><p>string (space seperated) or list or data frame of scientific names for species covered.</p></td>
+      <td><p>string (space separated) or list or data frame of scientific names for species covered.</p></td>
     </tr>
     <tr>
       <th>expand</th>
@@ -183,27 +186,18 @@ EML permits any rank names provided they go in descending order.</p>
   <span class='kw'>Genus</span> <span class='kw'>=</span> <span class='st'>"Macrocystis"</span>,
   <span class='kw'>Species</span> <span class='kw'>=</span> <span class='st'>"pyrifera"</span>
 )
-<span class='no'>taxon_coverage</span> <span class='kw'>&lt;-</span> <span class='fu'>set_taxonomicCoverage</span>(<span class='no'>sci_names</span>)
+<span class='no'>taxon_coverage</span> <span class='kw'>&lt;-</span> <span class='fu'>set_taxonomicCoverage</span>(<span class='no'>sci_names</span>)</div><div class='input'> <span class='co'># Examples that may take &gt; 5s</span>
 
 <span class='co'># Query ITIS using taxize to fill in the full taxonomy given just species</span>
 <span class='co'>#  # names</span>
 <span class='no'>taxon_coverage</span> <span class='kw'>&lt;-</span> <span class='fu'>set_taxonomicCoverage</span>(
   <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"Macrocystis pyrifera"</span>, <span class='st'>"Homo sapiens"</span>),
   <span class='kw'>expand</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>
-)</div><div class='output co'>#&gt; <span class='message'></span>
+)</div><div class='output co'>#&gt; <span class='message'>Registered S3 method overwritten by 'crul':</span>
+#&gt; <span class='message'>  method                 from</span>
+#&gt; <span class='message'>  as.character.form_file httr</span></div><div class='output co'>#&gt; <span class='message'></span>
 #&gt; <span class='message'>Retrieving data for taxon 'Macrocystis pyrifera'</span></div><div class='output co'>#&gt; <span class='message'></span>
-#&gt; <span class='message'>Retrieving data for taxon 'Homo sapiens'</span></div><div class='output co'>#&gt; <span class='warning'>Warning: &gt; 1 result; no direct match found</span></div><div class='output co'>#&gt; <span class='message'></span>
-#&gt; <span class='message'></span></div><div class='output co'>#&gt;      tsn                       target      commonNames nameUsage
-#&gt; 1 180092                 Homo sapiens man,Human,Humans     valid
-#&gt; 2 945628 Homo sapiens cro-magnonensis               NA   invalid
-#&gt; 3 945730  Homo sapiens cromagnonensis               NA   invalid
-#&gt; 4 945629   Homo sapiens grimaldiensis               NA   invalid</div><div class='output co'>#&gt; <span class='message'></span>
-#&gt; <span class='message'>More than one TSN found for taxon 'Homo sapiens'!</span>
-#&gt; <span class='message'></span>
-#&gt; <span class='message'>            Enter rownumber of taxon (other inputs will return 'NA'):</span></div><div class='output co'>#&gt; <span class='message'></span>
-#&gt; <span class='message'>Returned 'NA'!</span>
-#&gt; <span class='message'></span></div><div class='output co'>#&gt; <span class='warning'>Warning: Some scientific names were not found in the</span>
-#&gt; <span class='warning'>taxonomic database and were not expanded: Homo sapiens.</span></div><div class='input'>
+#&gt; <span class='message'>Retrieving data for taxon 'Homo sapiens'</span></div><div class='input'>
 <span class='co'># Query GBIF instead of ITIS</span>
 <span class='no'>taxon_coverage</span> <span class='kw'>&lt;-</span> <span class='fu'>set_taxonomicCoverage</span>(
   <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"Macrocystis pyrifera"</span>),
@@ -278,7 +272,8 @@ EML permits any rank names provided they go in descending order.</p>
 #&gt; 
 #&gt; 
 #&gt; 
-#&gt; </div></pre>
+#&gt; </div><div class='input'>
+</div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
     <h2>Contents</h2>
@@ -303,7 +298,7 @@ EML permits any rank names provided they go in descending order.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/set_unitList.html
+++ b/docs/reference/set_unitList.html
@@ -73,7 +73,7 @@ most common units." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -102,6 +102,9 @@ most common units." />
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -225,7 +228,7 @@ or other format and read them in to R for ready re-use.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/shiny_attributes.html
+++ b/docs/reference/shiny_attributes.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -101,6 +101,9 @@
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -171,7 +174,7 @@ entered attributes</p>
 <span class='no'>out</span> <span class='kw'>&lt;-</span> <span class='fu'>shiny_attributes</span>(<span class='no'>data</span>, <span class='kw'>NULL</span>)
 
 <span class='co'># from exisiting attributes</span>
-<span class='no'>file</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/system.file'>system.file</a></span>(<span class='st'>"tests"</span>, <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/options'>options</a></span>(<span class='st'>"emld_db"</span>),
+<span class='no'>file</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/system.file'>system.file</a></span>(<span class='st'>"tests"</span>, <span class='kw pkg'>emld</span><span class='kw ns'>::</span><span class='fu'><a href='https://www.rdocumentation.org/packages/emld/topics/eml_version'>eml_version</a></span>(),
   <span class='st'>"eml-datasetWithAttributelevelMethods.xml"</span>,
   <span class='kw'>package</span> <span class='kw'>=</span> <span class='st'>"emld"</span>
 )
@@ -203,7 +206,7 @@ entered attributes</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/table_to_r.html
+++ b/docs/reference/table_to_r.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -101,6 +101,9 @@
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -162,7 +165,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/docs/reference/write_eml.html
+++ b/docs/reference/write_eml.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">EML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.99.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">2.0.0</span>
       </span>
     </div>
 
@@ -101,6 +101,9 @@
       <a href="../articles/working-with-units.html">Working with Units</a>
     </li>
   </ul>
+</li>
+<li>
+  <a href="../news/index.html">Changelog</a>
 </li>
       </ul>
       
@@ -194,7 +197,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
       </footer>
    </div>

--- a/man/set_attributes.Rd
+++ b/man/set_attributes.Rd
@@ -42,7 +42,7 @@ For all data:
  case sensitive) but it can be inferred from col_classes.
 
 For numeric (ratio or interval) data:
-- unit (required)
+- unit (required). Unitless values should use "dimensionless" as the unit.
 
 For character (textDomain) data:
 - definition (required)

--- a/man/set_attributes.Rd
+++ b/man/set_attributes.Rd
@@ -30,42 +30,53 @@ The attributes data frame must use only the recognized column
 headers shown here.  The attributes data frame must contain columns for required metadata.
 These are:
 
-For all data:
-- attributeName (required, free text field)
+\strong{For all data:}
 
-- attributeDefinition (required, free text field)
+\itemize{
+  \item attributeName (required, free text field)
 
-- measurementScale (required, "nominal", "ordinal", "ratio", "interval", or "dateTime",
+  \item attributeDefinition (required, free text field)
+
+  \item measurementScale (required, "nominal", "ordinal", "ratio", "interval", or "dateTime",
  case sensitive) but it can be inferred from col_classes.
  
-- domain (required, "numericDomain", "textDomain", "enumeratedDomain", or "dateTimeDomain",
+  \item domain (required, "numericDomain", "textDomain", "enumeratedDomain", or "dateTimeDomain",
  case sensitive) but it can be inferred from col_classes.
+}
 
-For numeric (ratio or interval) data:
-- unit (required). Unitless values should use "dimensionless" as the unit.
+\strong{For numeric (ratio or interval) data:}
+\itemize{
+  \item unit (required). Unitless values should use "dimensionless" as the unit.
+}
 
-For character (textDomain) data:
-- definition (required)
+\strong{For character (textDomain) data:}
+\itemize{
+  \item definition (required)
+}
 
-For dateTime data:
-- formatString (required)
+\strong{For dateTime data:}
+\itemize{
+  \item formatString (required)
+}
 
 Other optional allowed columns in the attributes table are:
 source, pattern, precision, numberType, missingValueCode, missingValueCodeExplanation,
 attributeLabel, storageType, minimum, maximum
 
-The factors data frame, required for attributes in an enumerated domain, must use only the
+The \strong{factors} data frame, required for attributes in an enumerated domain, must use only the
  following recognized column headers:
+\itemize{
+  \item attributeName (required)
+  \item code (required)
+  \item definition (required)
+}
 
-- attributeName (required)
-- code (required)
-- definition (required)
-
-The missingValues data frame, optional, can be used in the case that multiple missing value codes
+The \strong{missingValues} data frame, optional, can be used in the case that multiple missing value codes
 need to be set for the same attribute. This table must contain the following recognized column
 headers.
-
-- attributeName (required)
-- code (required)
-- definition (required)
+\itemize{
+  \item attributeName (required)
+  \item code (required)
+  \item definition (required)
+}
 }

--- a/tests/testthat/test-set_attributes.R
+++ b/tests/testthat/test-set_attributes.R
@@ -991,3 +991,17 @@ test_that(
     )
   })
 
+test_that("set_attributes returns a warning when units unrecognised", {
+
+df <- data.frame(
+  attributeName = "freq_occ",
+  attributeDefinition = "Frequency of occurence",
+  unit = NA,
+  numberType = "real",
+  minimum = "0",
+  maximum = "1",
+  stringsAsFactors = FALSE)
+
+expect_warning(set_attributes(df, col_classes = "numeric"))
+
+})


### PR DESCRIPTION
Related to #274 

- added a note to the documentation in `set_attributes()` to prompt users to use "dimensionless" for values without units.

- included an additional note in the warning message, triggered only when the unrecognised unit is NA. 

- Formatted Roxygen documentation for readability (corrected bullet points and added some bold emphasis)

- Added a test for the unrecognised unit warning

- Rebuilt pkdown docs, initially just to update `set_attributes()` reference but seeing as docs still had the previous version, I rebuilt the lot. Perhaps you want to consider building docs with [tic](https://github.com/ropenscilabs/tic)? (what do reckon @maelle 😉).

Let me know if you want me to change anything!