### PR TITLE
set names of list input to set_taxonomicCoverage to NULL

### DIFF
--- a/R/set_coverage.R
+++ b/R/set_coverage.R
@@ -201,6 +201,7 @@ set_taxonomicCoverage <- function(sci_names, expand = FALSE, db = "itis") {
   } else if (is.data.frame(sci_names)) {
     set_taxonomicCoverage.data.frame(sci_names)
   } else if (is.list(sci_names)) {
+    names(sci_names) <- NULL
     set_taxonomicCoverage.list(sci_names)
   } else {
     stop("Incorrect format: sci_names


### PR DESCRIPTION
Fix to bug where character vector input creates named list elements under taxonomicClassification and therefore invalid EML. See issue #279.