### PR TITLE
replace ifelse() with if statement

### DIFF
--- a/R/set_attributes.R
+++ b/R/set_attributes.R
@@ -141,9 +141,9 @@ set_attribute <- function(row, factors = NULL, missingValues = NULL) {
           "' is not a recognized standard unit; treating as custom unit. ",
           "Please be sure you also define a custom unit in your EML record, ",
           "or replace with a recognized standard unit. ",
-          ifelse(is.na(row[["unit"]]), 
-                 'For unitless values, use "dimensionless" as the unit. ',
-                 NULL),
+          if(is.na(row[["unit"]])){
+            'For unitless values, use "dimensionless" as the unit. '
+          } ,
           "See set_unitList() for details."
       )
     } else {


### PR DESCRIPTION
When testing on a system that had the error described in issue #278 , this change makes the error go away and the code runs as expected. Still not sure of the root cause of the issue - some setups don't like `ifelse` for some reason - but this removes the offending function at least