### PR TITLE
Get attributes error catch

### DIFF
--- a/R/get_attributes.R
+++ b/R/get_attributes.R
@@ -19,12 +19,20 @@
 get_attributes <- function(x, eml = NULL) {
   attributeList <- x
   
+  ## check to make sure input appears to be an attributeList
+  if (!("attribute" %in% names(attributeList)) & is.null(attributeList$references)) {
+    stop(
+      call. = FALSE,
+      "Input does not appear to be an attributeList."
+    )
+  }  
+  
   ## if the attributeList is referenced, get reference
   if (!is.null(attributeList$references)) {
     if (is.null(eml)) {
       warning(
-        "The attributeList entered is referenced somewhere else in the eml.",
-        "No eml was entered to find the attributes.",
+        "The attributeList entered is referenced somewhere else in the eml. ",
+        "No eml was entered to find the attributes. ",
         "Please enter the eml to get better results."
       )
       eml <- x

--- a/tests/testthat/test-get_attributes.R
+++ b/tests/testthat/test-get_attributes.R
@@ -64,3 +64,17 @@ test_that("get_attributes works with references", {
   expect_gt(nrow(factors), 0)
   expect_gt(ncol(factors), 0)
 })
+
+test_that("get_attributes errors when not used with an attributeList", {
+  file <- system.file("tests", emld::eml_version(),
+                      "eml-datasetWithAttributelevelMethods.xml",
+                      package = "emld"
+  )
+  eml <- read_eml(file)
+  
+  x <- eml$dataset$dataTable
+  y <- eml$dataset$dataTable$attributeList$attribute
+  
+  expect_error(get_attributes(x))
+  expect_error(get_attributes(y))
+})

--- a/tests/testthat/test-set_attributes.R
+++ b/tests/testthat/test-set_attributes.R
@@ -922,9 +922,10 @@ test_that(
       definition = c("from table", "from table")
     )
     
-    att_list <- set_attributes(attributes, 
+    expect_warning(att_list <- set_attributes(attributes, 
                                col_classes = c("character", "character", "numeric"),
-                               missingValues = missing_values)
+                               missingValues = missing_values))
+    
     # set in both missing value and attributes table
     expect_equal("from table", att_list$attribute[[1]]$missingValueCode[[1]]$codeExplanation)
     # set only in attributes table


### PR DESCRIPTION
Give a helpful error message when `get_attributes` is passed something that doesn't look like an `attributeList`