### PR TITLE
add simplify argument to `eml_get`

### DIFF
--- a/R/eml_get.R
+++ b/R/eml_get.R
@@ -6,6 +6,8 @@
 #' If multiple occurrences are found, will extract all
 #' @param from explicit type for the input format. Possible values:
 #' "xml", "json", "list", or "guess" with "list" as the default.
+#' @param simplify simplify return value into a list (`TRUE`)
+#' or return an S3 `emld` typed object (`FALSE`).
 #' @param ... additional arguments
 #'
 #' @examples
@@ -22,10 +24,17 @@
 #' @importFrom jqr jq combine
 #' @importFrom emld as_json as_emld
 #' @importFrom jsonlite fromJSON
-eml_get <- function(x, element, from = "list", ...) {
+eml_get <- function(x, element, from = "list", simplify = FALSE, ...) {
   doc <- as.character(emld::as_json(emld::as_emld(x, from = from)))
   out <- jqr::jq(doc, paste0("..|.", element, "? // empty"))
   json <- jqr::combine(out)
   robj <- jsonlite::fromJSON(json, simplifyVector = FALSE)
-  emld::as_emld(robj)
+  
+  if (simplify & !is.atomic(robj)){
+    robj$`@context` <- NULL
+  }
+  else if (!simplify){
+    robj <- emld::as_emld(robj)
+  }
+  return(robj)
 }

--- a/man/eml_get.Rd
+++ b/man/eml_get.Rd
@@ -4,7 +4,7 @@
 \alias{eml_get}
 \title{eml_get}
 \usage{
-eml_get(x, element, from = "list", ...)
+eml_get(x, element, from = "list", simplify = FALSE, ...)
 }
 \arguments{
 \item{x}{an EML object or child/descendant object}
@@ -14,6 +14,9 @@ If multiple occurrences are found, will extract all}
 
 \item{from}{explicit type for the input format. Possible values:
 "xml", "json", "list", or "guess" with "list" as the default.}
+
+\item{simplify}{simplify return value into a list (`TRUE`)
+or return an S3 `emld` typed object (`FALSE`).}
 
 \item{...}{additional arguments}
 }

--- a/tests/testthat/test-eml_get.R
+++ b/tests/testthat/test-eml_get.R
@@ -26,3 +26,15 @@ test_that("eml_get works on more calls", {
     "attributeName"
   )
 })
+
+test_that("eml_get can return a simple list output", {
+  my_eml <- read_eml(f)
+  y <- eml_get(my_eml, "attributeName", simplify = T)
+  expect_equal(class(y), "list")
+  
+  y <- eml_get(
+    my_eml$dataset$dataTable$attributeList$attribute[[1]],
+    "attributeName",
+    simplify = T
+  )
+})


### PR DESCRIPTION
Addresses what I brought up in issue #303 

I decided to keep the default value to `FALSE` mainly to avoid having to deal with too many breaking changes.