### PR TITLE
Update get_attributes to handle attributeLists w single attribute, #285

### DIFF
--- a/R/get_attributes.R
+++ b/R/get_attributes.R
@@ -49,7 +49,7 @@ get_attributes <- function(x, eml = NULL) {
   }
   
   ## get attributes
-  attributes <- lapply(attributeList$attribute, function(x) {
+  getAttributes <- function(x) {
     
     ## get full attribute list
     atts <- unlist(x, recursive = TRUE, use.names = TRUE)
@@ -95,7 +95,16 @@ get_attributes <- function(x, eml = NULL) {
                         "",
                         names(atts))
     atts <- as.data.frame(t(atts), stringsAsFactors = FALSE)
-  })
+  }
+  
+  # use lapply for multiple attributes, otherwise pass in singular non-null attribute
+  attributes <- NULL
+  if (is.list(attributeList$attribute[[1]])) {
+    attributes <- lapply(attributeList$attribute, getAttributes)
+  } else if (!is.null(attributeList$attribute)) {
+    attributes <- getAttributes(attributeList$attribute)
+  }
+  
   attributes <- dplyr::bind_rows(attributes)
   
   ## remove non_fields in attributes
@@ -109,7 +118,7 @@ get_attributes <- function(x, eml = NULL) {
   attributes <- attributes[, !(names(attributes) %in% non_fields)]
   
   ## get factors
-  factors <- lapply(attributeList$attribute, function(x) {
+  getFactors <- function(x) {
     
     ## get factors
     factors <- eml_get(x, "enumeratedDomain")
@@ -125,7 +134,15 @@ get_attributes <- function(x, eml = NULL) {
     }
     
     return(factors)
-  })
+  }
+  
+  # use lapply for multiple attributes, otherwise pass in singular non-null attribute
+  factors <- NULL
+  if (is.list(attributeList$attribute[[1]])) {
+    factors <- lapply(attributeList$attribute, getFactors)
+  } else if (!is.null(attributeList$attribute)) {
+    factors <- getFactors(attributeList$attribute)
+  }
   
   factors <- dplyr::bind_rows(factors)
   


### PR DESCRIPTION
Under certain conditions (see reprex in #285), passing an attributeList with a single attribute into get_attributes will cause an error due to the use of lapply, which for multiple attributes (represented as a list of lists) will correctly apply the function to each attribute, but for a singular attribute (which can be just a flat list) would attempt to apply the function to each character element of the list and causes the error.

This fix attempts to prevent that error by identifying which case is being handled and applying the appropriate logic accordingly.

With that said, this fix feels a little hacky to me and if anyone has a better idea on how to handle it I very much welcome input.