### PR TITLE
align `set_taxonomicCoverage` behaviour with EML

### DIFF
--- a/R/set_coverage.R
+++ b/R/set_coverage.R
@@ -140,6 +140,8 @@ set_temporalCoverage <-
 #' @export
 #' @importFrom methods is
 #' @examples
+#' 
+#' taxon_coverage <- set_taxonomicCoverage("Macrocystis pyrifera")
 #'
 #' sci_names <- data.frame(
 #'   Kingdom = "Plantae",
@@ -148,7 +150,7 @@ set_temporalCoverage <-
 #'   Order = "Laminariales",
 #'   Family = "Lessoniaceae",
 #'   Genus = "Macrocystis",
-#'   Species = "pyrifera"
+#'   specificEpithet = "pyrifera"
 #' )
 #' taxon_coverage <- set_taxonomicCoverage(sci_names)
 #'
@@ -156,13 +158,13 @@ set_temporalCoverage <-
 #'
 #' ## use a list of lists for multiple species
 #' sci_names <- list(list(
-#'   Kindom = "Plantae",
+#'   Kingdom = "Plantae",
 #'   Phylum = "Phaeophyta",
 #'   Class = "Phaeophyceae",
 #'   Order = "Laminariales",
 #'   Family = "Lessoniaceae",
 #'   Genus = "Macrocystis",
-#'   Species = "pyrifera"
+#'   specificEpithet = "pyrifera"
 #' ))
 #' set_taxonomicCoverage(sci_names)
 #'
@@ -170,19 +172,13 @@ set_temporalCoverage <-
 set_taxonomicCoverage <- function(sci_names, expand = FALSE, db = "itis") {
   # Expand using taxadb and ITIS if the user passes in just scientific names
   if (is.character(sci_names) && expand) {
-    sci_names <- expand_scinames(sci_names, db)
+    sci_names <- list(expand_scinames(sci_names, db))
   }
   if (is.character(sci_names) && !expand) {
-    taxa <- lapply(strsplit(sci_names, " "), function(s) {
-      list(
-        taxonRankName = "Genus",
-        taxonRankValue = s[[1]],
-        taxonomicClassification = list(
-          taxonRankName = "Species",
-          taxonRankValue = s[[2]]
-        )
+      taxa <- list(
+        taxonRankName = "Species",
+        taxonRankValue = sci_names
       )
-    })
     list(taxonomicClassification = taxa)
   } else if (is.data.frame(sci_names)) {
     set_taxonomicCoverage.data.frame(sci_names)
@@ -194,7 +190,7 @@ set_taxonomicCoverage <- function(sci_names, expand = FALSE, db = "itis") {
 can only be character string, data.frame or list")
   }
 }
-
+  
 
 
 ## Recursively turn named list into nested list

--- a/R/set_coverage.R
+++ b/R/set_coverage.R
@@ -172,7 +172,7 @@ set_temporalCoverage <-
 set_taxonomicCoverage <- function(sci_names, expand = FALSE, db = "itis") {
   # Expand using taxadb and ITIS if the user passes in just scientific names
   if (is.character(sci_names) && expand) {
-    sci_names <- list(expand_scinames(sci_names, db))
+    sci_names <- expand_scinames(sci_names, db)
   }
   if (is.character(sci_names) && !expand) {
       taxa <- list(
@@ -236,5 +236,8 @@ expand_scinames <- function(sci_names, db){
          "Expansion of scientific names requires the 'taxadb' package to be installed. Install taxadb or set expand to FALSE."
         )}
   df <- taxadb::filter_name(sci_names, provider = db)
-  as.list(df[c("kingdom", "phylum", "class", "order", "family", "genus", "specificEpithet")])
+  
+  lapply(1:length(sci_names), function(i){
+    as.list(df[i,c("kingdom", "phylum", "class", "order", "family", "genus", "specificEpithet")])})
+  
 }

--- a/man/set_taxonomicCoverage.Rd
+++ b/man/set_taxonomicCoverage.Rd
@@ -33,6 +33,8 @@ EML permits any rank names provided they go in descending order.
 }
 \examples{
 
+taxon_coverage <- set_taxonomicCoverage("Macrocystis pyrifera")
+
 sci_names <- data.frame(
   Kingdom = "Plantae",
   Phylum = "Phaeophyta",
@@ -40,7 +42,7 @@ sci_names <- data.frame(
   Order = "Laminariales",
   Family = "Lessoniaceae",
   Genus = "Macrocystis",
-  Species = "pyrifera"
+  specificEpithet = "pyrifera"
 )
 taxon_coverage <- set_taxonomicCoverage(sci_names)
 
@@ -48,13 +50,13 @@ taxon_coverage <- set_taxonomicCoverage(sci_names)
 
 ## use a list of lists for multiple species
 sci_names <- list(list(
-  Kindom = "Plantae",
+  Kingdom = "Plantae",
   Phylum = "Phaeophyta",
   Class = "Phaeophyceae",
   Order = "Laminariales",
   Family = "Lessoniaceae",
   Genus = "Macrocystis",
-  Species = "pyrifera"
+  specificEpithet = "pyrifera"
 ))
 set_taxonomicCoverage(sci_names)
 

--- a/tests/testthat/test-set_taxonomicCoverage.R
+++ b/tests/testthat/test-set_taxonomicCoverage.R
@@ -9,7 +9,7 @@ test_that("set_taxonomicCoverage works with data.frame", {
     Order = "Laminariales",
     Family = "Lessoniaceae",
     Genus = "Macrocystis",
-    Species = "pyrifera"
+    specificEpithet = "pyrifera"
   )
   taxon_coverage <- set_taxonomicCoverage(sci_names)
 
@@ -26,7 +26,7 @@ test_that("set_taxonomicCoverage works with nested lists", {
     Order = "Laminariales",
     Family = "Lessoniaceae",
     Genus = "Macrocystis",
-    Species = "pyrifera"
+    specificEpithet = "pyrifera"
   ))
   x <- set_taxonomicCoverage(sci_names)
 

--- a/tests/testthat/test-set_taxonomicCoverage.R
+++ b/tests/testthat/test-set_taxonomicCoverage.R
@@ -20,7 +20,7 @@ test_that("set_taxonomicCoverage works with data.frame", {
 
 test_that("set_taxonomicCoverage works with nested lists", {
   sci_names <- list(list(
-    Kindom = "Plantae",
+    Kingdom = "Plantae",
     Phylum = "Phaeophyta",
     Class = "Phaeophyceae",
     Order = "Laminariales",

--- a/vignettes/working-with-units.Rmd
+++ b/vignettes/working-with-units.Rmd
@@ -4,7 +4,7 @@ author: "Carl Boettiger"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Working with units}
+  %\VignetteIndexEntry{Working with Units}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
This addresses what was described in #328 
- Changes the behavior of `set_taxonomicCoverage` to not split species names and keeps it as the `<Genus> <specificEpithet>  <intraSpecificEpithet>` 
- Updates the examples given to use `specificEpithet`
- Tweaked `expand_scinames` to handle situations when more than one species is given and return a list