### PR TITLE
make `get_attributes` fully compatible with annotations

### DIFF
--- a/R/get_attributes.R
+++ b/R/get_attributes.R
@@ -91,6 +91,14 @@ get_attributes <- function(x, eml = NULL) {
                         "propertyLabel",
                         names(atts),
                         fixed = TRUE)
+    names(atts) <- gsub("annotation.propertyURI.propertyURI",
+                        "propertyURI",
+                        names(atts),
+                        fixed = TRUE)
+    names(atts) <- gsub("annotation.valueURI.valueURI",
+                        "valueURI",
+                        names(atts),
+                        fixed = TRUE)
     names(atts) <- gsub(".+\\.+",
                         "",
                         names(atts))


### PR DESCRIPTION
Some names in the attribute list were re-named to fit with other tools, but not the ones associated with URIs. I just added a few lines to fix those so that all of the annotation information is retrieved.