### PR TITLE
Allow set_responsibleParty to create organizations

### DIFF
--- a/R/set_responsibleParty.R
+++ b/R/set_responsibleParty.R
@@ -16,8 +16,16 @@
 #' @export
 #'
 #' @examples
+#' # Pass in either a person object or separate values to create an individual
 #' carl <- set_responsibleParty(as.person("Carl Boettiger <cboettig@ropensci.org>"))
 #' matt <- set_responsibleParty("Matthew", "Jones", email = "mbjones@@nceas.ucsb.edu")
+#'
+#' # To create an organization, used the named `organization` argument to
+#' specify the organization name
+#' my_org <- set_responsibleParty(
+#'   organization = "My Organization",
+#'   email = "contact@example.org"
+#' )
 set_responsibleParty <-
   function(givenName = NULL,
              surName = NULL,
@@ -30,8 +38,13 @@ set_responsibleParty <-
              userId = NULL,
              id = NULL,
              email = NULL) {
-    UseMethod("set_responsibleParty", givenName)
-  }
+
+    if (is(givenName, "person")) {
+      UseMethod("set_responsibleParty", givenName)
+    } else {
+      UseMethod("set_responsibleParty", c(surName, organizationName))
+    }
+}
 
 #' @export
 set_responsibleParty.person <- function(givenName, ...) {

--- a/tests/testthat/test-set_responsibleParty.R
+++ b/tests/testthat/test-set_responsibleParty.R
@@ -21,3 +21,24 @@ testthat::test_that("We can set responsible party", {
   testthat::expect_true(eml_validate("ex.xml"))
   unlink("ex.xml")
 })
+
+testthat::test_that("We can set a responsible party that's an organization", {
+  # Verify this way of calling the function works
+  party <- set_responsibleParty(organizationName = "Some Organization")
+  testthat::expect_equal(party$organizationName, "Some Organization")
+
+  # Also verify we create valid documents when doing so
+  doc <- list(
+    dataset = list(
+      title = "dataset title",
+      contact = party,
+      creator = party
+    ),
+    system = "doi",
+    packageId = "10.xxx"
+  )
+
+  write_eml(doc, "ex.xml")
+  testthat::expect_true(eml_validate("ex.xml"))
+  unlink("ex.xml")
+})


### PR DESCRIPTION
Closes https://github.com/ropensci/EML/issues/345

Previously, passing only the organization argument would error out because UseMethod was dispatching on givenName which is NULL in the case of creating an organization.